### PR TITLE
make suite.out user-friendly

### DIFF
--- a/src/tests/suite.run
+++ b/src/tests/suite.run
@@ -66,6 +66,8 @@ echo -ne "" &> $out;
 for (( i=1; i <= ${#testcases[@]}; i++ ))
 do
 	echo -ne "Running libica test suite (writing to "$out") ... "$i"/"${#testcases[@]}"\r";
+	echo "Running '${testcases[i-1]}' ..." >> $out;
 	./${testcases[i-1]} >> $out 2>&1;
+	echo -ne "... done\n\n" >> $out;
 done
 echo -ne "\n";


### PR DESCRIPTION
Put some separators to the test cases outputs so suite.out
is more readable.