### PR TITLE
Fix tests with environment variables

### DIFF
--- a/src/tests/suite.run
+++ b/src/tests/suite.run
@@ -80,7 +80,7 @@ for (( i=1; i <= ${#testcases[@]}; i++ ))
 do
 	echo -ne "Running libica test suite (writing to "$out") ... "$i"/"${#testcases[@]}"\r";
 	echo "Running '${testcases[i-1]}' ..." >> $out;
-	./${testcases[i-1]} >> $out 2>&1;
+	PATH=./:$PATH bash -c "${testcases[i-1]}" >> $out 2>&1;
 	echo -ne "... done\n\n" >> $out;
 done
 echo -ne "\n";


### PR DESCRIPTION
Currently for tests that set an environment variable we get errors like the following:

```
 # ./suite.run
 Running 'ICAPATH=1 libica_ecdh_test ' ...
 ./suite.run: line 30: ./ICAPATH=1: No such file or directory
 ... done
```

Fix this by calling the tests with "bash -c" and including the current directory into the PATH variable.

Signed-off-by: Michael Holzheu <holzheu@linux.vnet.ibm.com>