### PR TITLE
New API function to set libica fallback mode.

### DIFF
--- a/include/ica_api.h
+++ b/include/ica_api.h
@@ -426,6 +426,14 @@ typedef struct ica_drbg ica_drbg_t;
 #define ICA_FALLBACKS_DISABLED 0
 
 /**
+ * Environment variable for defining the default Libica fallback mode.
+ * By default Libica starts with fallbacks enabled. When this environment
+ * variable exists and has a numeric value, the fallback mode is set
+ * via ica_set_fallback_mode().
+ */
+#define ICA_FALLBACK_ENV "LIBICA_FALLBACK_MODE"
+
+/**
  * Set Libica fallback mode.
  * With fallbacks enabled (that's the default), when there is no hardware
  * support available (for example when the crypto cards are offline) Libica

--- a/include/ica_api.h
+++ b/include/ica_api.h
@@ -420,6 +420,24 @@ typedef struct ica_drbg_mech ica_drbg_mech_t;
 typedef struct ica_drbg ica_drbg_t;
 
 /**
+ * Definitions for the ica_set_fallback_mode function.
+ */
+#define ICA_FALLBACKS_ENABLED  1
+#define ICA_FALLBACKS_DISABLED 0
+
+/**
+ * Set Libica fallback mode.
+ * With fallbacks enabled (that's the default), when there is no hardware
+ * support available (for example when the crypto cards are offline) Libica
+ * attempts to cover the request by calling Openssl functions as fallback.
+ * With fallback disabled, no attempts will be made to fulfill the request
+ * if there is no hardware support or hardware invocation fails. Instead
+ * the function will return with ENODEV.
+ */
+ICA_EXPORT
+void ica_set_fallback_mode(int fallback_mode);
+
+/**
  * Opens the specified adapter
  * @param adapter_handle Pointer to the file descriptor for the adapter or
  * to DRIVER_NOT_LOADED if opening the crypto adapter failed.

--- a/libica.map
+++ b/libica.map
@@ -110,6 +110,7 @@ LIBICA_3.2.0 {
 
 LIBICA_3.2.1 {
     global:
+	ica_set_fallback_mode;
 	ica_ec_key_new;
 	ica_ec_key_init;
 	ica_ec_key_generate;

--- a/src/include/init.h
+++ b/src/include/init.h
@@ -22,5 +22,7 @@
 int begin_sigill_section(struct sigaction *oldact, sigset_t * oldset);
 void end_sigill_section(struct sigaction *oldact, sigset_t * oldset);
 
+extern int ica_fallbacks_enabled;
+
 #endif
 

--- a/src/include/s390_cmac.h
+++ b/src/include/s390_cmac.h
@@ -6,7 +6,7 @@
 
 /**
  * Authors: Ruben Straus <rstraus@de.ibm.com>
- * 	    Holger Dengler <hd@linux.vnet.ibm.com>
+ *	    Holger Dengler <hd@linux.vnet.ibm.com>
  *
  * Copyright IBM Corp. 2010, 2011
  */
@@ -176,7 +176,7 @@ static inline int s390_cmac(unsigned long fc,
 		     unsigned int  mac_length, unsigned char *mac,
 		     unsigned char *iv)
 {
-	int rc;
+	int rc = ENODEV;
 
 	if (*s390_msa4_functions[fc].enabled)
 		rc = s390_cmac_hw(s390_msa4_functions[fc].hw_fc,
@@ -184,11 +184,7 @@ static inline int s390_cmac(unsigned long fc,
 				  key_length, key,
 				  mac_length, mac,
 				  iv);
-	else {
-		return EPERM;
-	}
 
 	return rc;
 }
 #endif
-

--- a/src/include/s390_gcm.h
+++ b/src/include/s390_gcm.h
@@ -100,7 +100,7 @@ static inline int s390_ghash(const unsigned char *in_data, unsigned long data_le
 		      const unsigned char *key, unsigned char *iv)
 {
 	if (!s390_kimd_functions[GHASH].enabled)
-		return EPERM;
+		return ENODEV;
 
 	return s390_ghash_hw(s390_kimd_functions[GHASH].hw_fc,
 			     in_data, data_length,
@@ -331,7 +331,7 @@ static inline int s390_gcm(unsigned int function_code,
 	unsigned int rc;
 
 	if (!msa4_switch)
-		return EPERM;
+		return ENODEV;
 
 	/* calculate subkey H */
 	rc = s390_aes_ecb(UNDIRECTED_FC(function_code),
@@ -520,7 +520,7 @@ static inline int s390_gcm_intermediate(unsigned int function_code,
 	unsigned char *in, *out;
 
 	if (!msa4_switch)
-		return EPERM;
+		return ENODEV;
 
 	if (!msa8_switch) {
 		if (function_code % 2) {
@@ -729,7 +729,7 @@ static inline int s390_aes_gcm_kma(const unsigned char *in_data,
 		if (end_of_data)
 			hw_fc = hw_fc | LPC_FLAG;
 	} else {
-		return EPERM;
+		return ENODEV;
 	}
 
 	if (!aad)

--- a/src/init.c
+++ b/src/init.c
@@ -81,14 +81,6 @@ void end_sigill_section(struct sigaction *oldact, sigset_t *oldset)
 	sigprocmask(SIG_SETMASK, oldset, 0);
 }
 
-void openssl_init(void)
-{
-	/* initial seed the openssl random generator */
-	unsigned char random_data[64];
-	s390_prng(random_data, sizeof(random_data));
-	RAND_seed(random_data, sizeof(random_data));
-}
-
 /* Switches have to be done first. Otherwise we will not have hw support
  * in initialization */
 void __attribute__ ((constructor)) icainit(void)
@@ -118,8 +110,6 @@ void __attribute__ ((constructor)) icainit(void)
 		s390_prng_init();
 
 		s390_initialize_functionlist();
-
-		openssl_init();
 
 		/* check for fallback mode environment variable */
 		ptr = getenv(ICA_FALLBACK_ENV);

--- a/src/init.c
+++ b/src/init.c
@@ -19,6 +19,7 @@
 #include <string.h>
 #include <openssl/rand.h>
 #include <syslog.h>
+#include <stdio.h>
 
 #include "init.h"
 #include "fips.h"
@@ -92,6 +93,9 @@ void openssl_init(void)
  * in initialization */
 void __attribute__ ((constructor)) icainit(void)
 {
+	int value;
+	const char *ptr;
+
 	/* some init stuff but only when application is NOT icastats */
 	if (strcmp(program_invocation_name, "icastats")) {
 
@@ -116,6 +120,11 @@ void __attribute__ ((constructor)) icainit(void)
 		s390_initialize_functionlist();
 
 		openssl_init();
+
+		/* check for fallback mode environment variable */
+		ptr = getenv(ICA_FALLBACK_ENV);
+		if (ptr && sscanf(ptr, "%i", &value) == 1)
+			ica_set_fallback_mode(value);
 	}
 }
 

--- a/src/s390_crypto.c
+++ b/src/s390_crypto.c
@@ -173,7 +173,6 @@ void set_switches(int msa)
 {
 	unsigned char mask[16];
 	unsigned int n;
-	unsigned int on = 0;
 	struct sigaction oldact;
 	sigset_t oldset;
 
@@ -196,13 +195,9 @@ void set_switches(int msa)
 		}
 	}
 	for (n = 0; n < (sizeof(s390_kmc_functions) /
-			 sizeof(s390_supported_function_t)); n++) {
+			 sizeof(s390_supported_function_t)); n++)
 		if (S390_CRYPTO_TEST_MASK(mask, s390_kmc_functions[n].hw_fc))
-			on = 1;
-		else
-			on = 0;
-		*s390_kmc_functions[n].enabled = on;
-	}
+			*s390_kmc_functions[n].enabled = 1;
 
 	/* kimd query */
 	memset(mask, 0, sizeof(mask));
@@ -213,13 +208,9 @@ void set_switches(int msa)
 		}
 	}
 	for (n = 0; n < (sizeof(s390_kimd_functions) /
-			 sizeof(s390_supported_function_t)); n++) {
+			 sizeof(s390_supported_function_t)); n++)
 		if (S390_CRYPTO_TEST_MASK(mask, s390_kimd_functions[n].hw_fc))
-			on = 1;
-		else
-			on = 0;
-		*s390_kimd_functions[n].enabled = on;
-	}
+			*s390_kimd_functions[n].enabled = 1;
 
 	/* ppno query */
 	memset(mask, 0, sizeof(mask));
@@ -231,13 +222,9 @@ void set_switches(int msa)
 		}
 	}
 	for (n = 0; n < (sizeof(s390_ppno_functions) /
-			 sizeof(s390_supported_function_t)); n++) {
+			 sizeof(s390_supported_function_t)); n++)
 		if (S390_CRYPTO_TEST_MASK(mask, s390_ppno_functions[n].hw_fc))
-			on = 1;
-		else
-			on = 0;
-		*s390_ppno_functions[n].enabled = on;
-	}
+			*s390_ppno_functions[n].enabled = 1;
 
 	/* kma query */
 	memset(mask, 0, sizeof(mask));
@@ -249,13 +236,9 @@ void set_switches(int msa)
 		}
 	}
 	for (n = 0; n < (sizeof(s390_kma_functions) /
-			 sizeof(s390_supported_function_t)); n++) {
+			 sizeof(s390_supported_function_t)); n++)
 		if (S390_CRYPTO_TEST_MASK(mask, s390_kma_functions[n].hw_fc))
-			on = 1;
-		else
-			on = 0;
-		*s390_kma_functions[n].enabled = on;
-	}
+			*s390_kma_functions[n].enabled = 1;
 }
 
 void s390_crypto_switches_init(void)
@@ -282,30 +265,30 @@ void s390_crypto_switches_init(void)
  * The last filed represent the property flags
  */
 libica_func_list_element_int icaList[] = {
- {SHA1,   KIMD, SHA_1  		, ICA_FLAG_SW, 0},
- {SHA224, KIMD, SHA_256		, ICA_FLAG_SW, 0},
- {SHA256, KIMD, SHA_256		, ICA_FLAG_SW, 0},
- {SHA384, KIMD, SHA_512		, ICA_FLAG_SW, 0},
- {SHA512, KIMD, SHA_512		, ICA_FLAG_SW, 0},
+ {SHA1,   KIMD, SHA_1  , ICA_FLAG_SW, 0},
+ {SHA224, KIMD, SHA_256, ICA_FLAG_SW, 0},
+ {SHA256, KIMD, SHA_256, ICA_FLAG_SW, 0},
+ {SHA384, KIMD, SHA_512, ICA_FLAG_SW, 0},
+ {SHA512, KIMD, SHA_512, ICA_FLAG_SW, 0},
  {SHA3_224, KIMD, SHA_3_224, 0, 0},
  {SHA3_256, KIMD, SHA_3_256, 0, 0},
  {SHA3_384, KIMD, SHA_3_384, 0, 0},
  {SHA3_512, KIMD, SHA_3_512, 0, 0},
  {SHAKE128, KIMD, SHAKE_128, 0, 0},
  {SHAKE256, KIMD, SHAKE_256, 0, 0},
- {G_HASH, KIMD, GHASH		,           0, 0},
+ {G_HASH, KIMD, GHASH, 0, 0},
 
  {DES_ECB,      KMC,  DEA_ENCRYPT, ICA_FLAG_SW, 0},
  {DES_CBC,      KMC,  DEA_ENCRYPT, ICA_FLAG_SW, 0},
  {DES_OFB,      MSA4, DEA_ENCRYPT, 0, 0},
  {DES_CFB,      MSA4, DEA_ENCRYPT, 0, 0},
  {DES_CTR,      MSA4, DEA_ENCRYPT, 0, 0},
- {DES_CMAC,     MSA4, DEA_ENCRYPT, 0, 0},				// CPACF only (MSA4)
+ {DES_CMAC,     MSA4, DEA_ENCRYPT, 0, 0}, // CPACF only (MSA4)
 
  {DES3_ECB,     KMC,  TDEA_192_ENCRYPT, ICA_FLAG_SW, 0},
  {DES3_CBC,     KMC,  TDEA_192_ENCRYPT, ICA_FLAG_SW, 0},
  {DES3_OFB,     MSA4, TDEA_192_ENCRYPT,           0, 0},
- {DES3_CFB,     MSA4, TDEA_192_ENCRYPT, 	  0, 0},
+ {DES3_CFB,     MSA4, TDEA_192_ENCRYPT,           0, 0},
  {DES3_CTR,     MSA4, TDEA_192_ENCRYPT,           0, 0},
  {DES3_CMAC,    MSA4, TDEA_192_ENCRYPT,           0, 0},
 
@@ -315,19 +298,19 @@ libica_func_list_element_int icaList[] = {
  {AES_CFB,      MSA4, AES_128_ENCRYPT,           0, 0},
  {AES_CTR,      MSA4, AES_128_ENCRYPT,           0, 0},
  {AES_CMAC,     MSA4, AES_128_ENCRYPT,           0, 0},
- {AES_CCM,      MSA4, AES_128_ENCRYPT, 	         0, 0},
+ {AES_CCM,      MSA4, AES_128_ENCRYPT,           0, 0},
  {AES_GCM,      MSA4, AES_128_ENCRYPT,           0, 0},
  {AES_GCM_KMA,  MSA8, AES_128_GCM_ENCRYPT,       0, 0},
  {AES_XTS,      MSA4, AES_128_XTS_ENCRYPT,       0, 0},
- {P_RNG,    		ADAPTER, 0, ICA_FLAG_SHW | ICA_FLAG_SW, 0},	// SHW (CPACF) + SW
- {EC_DH,		ADAPTER, 0, ICA_FLAG_DHW | ICA_FLAG_SW, 0x0F},
+ {P_RNG,        ADAPTER, 0, ICA_FLAG_SHW | ICA_FLAG_SW, 0}, // SHW (CPACF) + SW
+ {EC_DH,        ADAPTER, 0, ICA_FLAG_DHW | ICA_FLAG_SW, 0x0F},
  {EC_DSA_SIGN,	ADAPTER, 0, ICA_FLAG_DHW | ICA_FLAG_SW, 0x0F},
  {EC_DSA_VERIFY, ADAPTER, 0, ICA_FLAG_DHW | ICA_FLAG_SW, 0x0F},
- {EC_KGEN,		ADAPTER, 0, ICA_FLAG_DHW | ICA_FLAG_SW, 0x0F},
- {RSA_ME, 		ADAPTER, 0, ICA_FLAG_DHW | ICA_FLAG_SW, 0x0F},	// DHW (CEX) + SW / 512,1024,2048, 4096 bit key length
- {RSA_CRT, 		ADAPTER, 0, ICA_FLAG_DHW | ICA_FLAG_SW, 0x0F},	// DHW (CEX) + SW / 512,1024,2048, 4096 bit key length
- {RSA_KEY_GEN_ME,  	ADAPTER, 0, ICA_FLAG_SW, 		0},	// SW (openssl)
- {RSA_KEY_GEN_CRT, 	ADAPTER, 0, ICA_FLAG_SW, 		0},	// SW (openssl)
+ {EC_KGEN,      ADAPTER, 0, ICA_FLAG_DHW | ICA_FLAG_SW, 0x0F},
+ {RSA_ME,       ADAPTER, 0, ICA_FLAG_DHW | ICA_FLAG_SW, 0x0F}, // DHW (CEX) + SW / 512,1024,2048, 4096 bit key length
+ {RSA_CRT,      ADAPTER, 0, ICA_FLAG_DHW | ICA_FLAG_SW, 0x0F}, // DHW (CEX) + SW / 512,1024,2048, 4096 bit key length
+ {RSA_KEY_GEN_ME, ADAPTER, 0, ICA_FLAG_SW, 0},  // SW (openssl)
+ {RSA_KEY_GEN_CRT, ADAPTER, 0, ICA_FLAG_SW, 0}, // SW (openssl)
 
  {SHA512_DRNG, PPNO, SHA512_DRNG_GEN, ICA_FLAG_SW, 0},
 
@@ -347,52 +330,47 @@ int s390_initialize_functionlist() {
 
   unsigned int x;
   for (x = 0; x < list_len; x++) {
-	switch ((int)icaList[x].type) {
+	libica_func_list_element_int *e = &icaList[x];
+	switch ((int) e->type) {
 	case KIMD:
-		icaList[x].flags = icaList[x].flags |
-		    ((*s390_kimd_functions[icaList[x].id].enabled)? 4: 0);
-	break;
+		e->flags |= *s390_kimd_functions[e->id].enabled ? 4 : 0;
+		break;
 	case KMC:
-		icaList[x].flags = icaList[x].flags |
-		((*s390_kmc_functions[icaList[x].id].enabled)? 4: 0);
-		if (icaList[x].id == AES_128_ENCRYPT) { // check for the maximum size
-		  if (*s390_kmc_functions[icaList[AES_256_ENCRYPT].id].enabled)
-			icaList[x].property = icaList[x].property | 4; // 256 bit
-		  if (*s390_kmc_functions[icaList[AES_192_ENCRYPT].id].enabled)
-			icaList[x].property = icaList[x].property | 2; // 192 bit
-		  if (*s390_kmc_functions[icaList[AES_128_ENCRYPT].id].enabled)
-			icaList[x].property = icaList[x].property | 1; // 128 bit
+		e->flags |= *s390_kmc_functions[e->id].enabled ? 4 : 0;
+		if (e->id == AES_128_ENCRYPT) { // check for the maximum size
+			if (*s390_kmc_functions[icaList[AES_256_ENCRYPT].id].enabled)
+				e->property |= 4; // 256 bit
+			if (*s390_kmc_functions[icaList[AES_192_ENCRYPT].id].enabled)
+				e->property |= 2; // 192 bit
+			if (*s390_kmc_functions[icaList[AES_128_ENCRYPT].id].enabled)
+				e->property |= 1; // 128 bit
 		}
-	break;
+		break;
 	case MSA4:
-		icaList[x].flags = icaList[x].flags |
-		((*s390_msa4_functions[icaList[x].id].enabled)? 4: 0);
-		  if (icaList[x].id == AES_128_ENCRYPT) { // check for the maximum size
+		e->flags |= *s390_msa4_functions[e->id].enabled ? 4 : 0;
+		if (e->id == AES_128_ENCRYPT) { // check for the maximum size
 			if (*s390_msa4_functions[icaList[AES_256_ENCRYPT].id].enabled)
-				icaList[x].property = icaList[x].property | 4; // 256 bit
+				e->property |= 4; // 256 bit
 			if (*s390_msa4_functions[icaList[AES_192_ENCRYPT].id].enabled)
-				icaList[x].property = icaList[x].property | 2; // 192 bit
+				e->property |= 2; // 192 bit
 			if (*s390_msa4_functions[icaList[AES_128_ENCRYPT].id].enabled)
-				icaList[x].property = icaList[x].property | 1; // 128 bit
-		  }
-		  else if (icaList[x].id == AES_128_XTS_ENCRYPT) { // check for the maximum size
+				e->property |= 1; // 128 bit
+		} else if (e->id == AES_128_XTS_ENCRYPT) { // check for the maximum size
 			if (*s390_msa4_functions[icaList[AES_256_XTS_ENCRYPT].id].enabled)
-				icaList[x].property = icaList[x].property | 2; // 256 bit
+				e->property |= 2; // 256 bit
 			if (*s390_msa4_functions[icaList[AES_128_XTS_ENCRYPT].id].enabled)
-				icaList[x].property = icaList[x].property | 1; // 128 bit
+				e->property |= 1; // 128 bit
 		}
-	break;
+		break;
 	case PPNO:
-		icaList[x].flags = icaList[x].flags |
-		    ((*s390_ppno_functions[icaList[x].id].enabled)? 4: 0);
-	break;
+		e->flags |= *s390_ppno_functions[e->id].enabled ? 4 : 0;
+		break;
 	case MSA8:
-		icaList[x].flags = icaList[x].flags |
-		((*s390_kma_functions[icaList[x].id].enabled)? 4: 0);
-	break;
+		e->flags |= *s390_kma_functions[e->id].enabled ? 4 : 0;
+		break;
 	default:
 		/* Do nothing. */
-	break;
+		break;
 	}
   }
   return 0;

--- a/src/s390_crypto.c
+++ b/src/s390_crypto.c
@@ -33,7 +33,7 @@
 unsigned int sha1_switch, sha256_switch, sha512_switch, sha3_switch, des_switch,
 	     tdes_switch, aes128_switch, aes192_switch, aes256_switch,
 	     prng_switch, tdea128_switch, tdea192_switch, sha512_drng_switch,
-	     msa4_switch, msa5_switch, msa8_switch;
+	     msa4_switch, msa5_switch, msa8_switch, trng_switch;
 
 s390_supported_function_t s390_kimd_functions[] = {
 	{SHA_1, S390_CRYPTO_SHA_1, &sha1_switch},
@@ -88,6 +88,7 @@ s390_supported_function_t s390_msa4_functions[] = {
 s390_supported_function_t s390_ppno_functions[] = {
 	{SHA512_DRNG_GEN, S390_CRYPTO_SHA512_DRNG_GEN, &sha512_drng_switch},
 	{SHA512_DRNG_SEED, S390_CRYPTO_SHA512_DRNG_SEED, &sha512_drng_switch},
+	{TRNG, S390_CRYPTO_TRNG, &trng_switch},
 };
 
 s390_supported_function_t s390_kma_functions[] = {

--- a/src/s390_sha.c
+++ b/src/s390_sha.c
@@ -229,12 +229,14 @@ int s390_sha1(unsigned char *iv, unsigned char *input_data,
 	      unsigned int input_length, unsigned char *output_data,
 	      unsigned int message_part, uint64_t *running_length)
 {
-	int rc = 1;
+	int rc = ENODEV;
 	if (sha1_switch)
 		rc = s390_sha_hw(iv, input_data, input_length, output_data,
 				sha_constants[SHA_1].hash_length,
 				 message_part, running_length, NULL, SHA_1);
 	if (rc) {
+		if (!ica_fallbacks_enabled)
+			return rc;
 		rc = s390_sha1_sw(iv, input_data, input_length, output_data,
 				  message_part, running_length);
 		stats_increment(ICA_STATS_SHA1, ALGO_SW, ENCRYPT);
@@ -248,12 +250,14 @@ int s390_sha224(unsigned char *iv, unsigned char *input_data,
 		unsigned int input_length, unsigned char *output_data,
 		unsigned int message_part, uint64_t *running_length)
 {
-	int rc = 1;
+	int rc = ENODEV;
 	if (sha256_switch)
 		rc = s390_sha_hw(iv, input_data, input_length, output_data,
 				sha_constants[SHA_224].hash_length,
 				 message_part, running_length, NULL, SHA_224);
 	if (rc) {
+		if (!ica_fallbacks_enabled)
+			return rc;
 		rc = s390_sha224_sw(iv, input_data, input_length, output_data,
 				  message_part, running_length);
 		stats_increment(ICA_STATS_SHA224, ALGO_SW, ENCRYPT);
@@ -267,12 +271,14 @@ int s390_sha256(unsigned char *iv, unsigned char *input_data,
 		unsigned int input_length, unsigned char *output_data,
 		unsigned int message_part, uint64_t *running_length)
 {
-	int rc = 1;
+	int rc = ENODEV;
 	if (sha256_switch)
 		rc = s390_sha_hw(iv, input_data, input_length, output_data,
 				sha_constants[SHA_256].hash_length,
 				 message_part, running_length, NULL, SHA_256);
 	if (rc) {
+		if (!ica_fallbacks_enabled)
+			return rc;
 		rc = s390_sha256_sw(iv, input_data, input_length, output_data,
 				    message_part, running_length);
 		stats_increment(ICA_STATS_SHA256, ALGO_SW, ENCRYPT);
@@ -286,13 +292,15 @@ int s390_sha384(unsigned char *iv, unsigned char *input_data,
 		unsigned int message_part, uint64_t *running_length_lo,
 		uint64_t *running_length_hi)
 {
-	int rc = 1;
+	int rc = ENODEV;
 	if (sha512_switch)
 		rc = s390_sha_hw(iv, input_data, input_length, output_data,
 				 sha_constants[SHA_384].hash_length,
 				 message_part, running_length_lo,
 				 running_length_hi, SHA_384);
 	if (rc) {
+		if (!ica_fallbacks_enabled)
+			return rc;
 		rc = s390_sha384_sw(iv, input_data, input_length, output_data,
 				    message_part, running_length_lo,
 				    running_length_hi);
@@ -308,13 +316,15 @@ int s390_sha512(unsigned char *iv, unsigned char *input_data,
 		unsigned int message_part, uint64_t *running_length_lo,
 		uint64_t *running_length_hi)
 {
-	int rc = 1;
+	int rc = ENODEV;
 	if (sha512_switch)
 		rc = s390_sha_hw(iv, input_data, input_length, output_data,
 				sha_constants[SHA_512].hash_length,
 				 message_part, running_length_lo,
 				 running_length_hi, SHA_512);
 	if (rc) {
+		if (!ica_fallbacks_enabled)
+			return rc;
 		rc = s390_sha512_sw(iv, input_data, input_length, output_data,
 				    message_part, running_length_lo,
 				    running_length_hi);
@@ -329,7 +339,7 @@ int s390_sha3_224(unsigned char *iv, unsigned char *input_data,
 		unsigned int input_length, unsigned char *output_data,
 		unsigned int message_part, uint64_t *running_length)
 {
-	int rc = EPERM;
+	int rc = ENODEV;
 
 	if (sha3_switch)
 		rc = s390_sha_hw(iv, input_data, input_length, output_data,
@@ -345,7 +355,7 @@ int s390_sha3_256(unsigned char *iv, unsigned char *input_data,
 		unsigned int input_length, unsigned char *output_data,
 		unsigned int message_part, uint64_t *running_length)
 {
-	int rc = EPERM;
+	int rc = ENODEV;
 
 	if (sha3_switch)
 		rc = s390_sha_hw(iv, input_data, input_length, output_data,
@@ -362,7 +372,7 @@ int s390_sha3_384(unsigned char *iv, unsigned char *input_data,
 		unsigned int message_part, uint64_t *running_length_lo,
 		uint64_t *running_length_hi)
 {
-	int rc = EPERM;
+	int rc = ENODEV;
 
 	if (sha3_switch)
 		rc = s390_sha_hw(iv, input_data, input_length, output_data,
@@ -380,7 +390,7 @@ int s390_sha3_512(unsigned char *iv, unsigned char *input_data,
 		unsigned int message_part, uint64_t *running_length_lo,
 		uint64_t *running_length_hi)
 {
-	int rc = EPERM;
+	int rc = ENODEV;
 
 	if (sha3_switch)
 		rc = s390_sha_hw(iv, input_data, input_length, output_data,
@@ -398,7 +408,7 @@ int s390_shake_128(unsigned char *iv, unsigned char *input_data,
 		unsigned int message_part, uint64_t *running_length_lo,
 		uint64_t *running_length_hi)
 {
-	int rc = EPERM;
+	int rc = ENODEV;
 
 	if (sha3_switch)
 		rc = s390_sha_hw(iv, input_data, input_length, output_data, output_length,
@@ -415,7 +425,7 @@ int s390_shake_256(unsigned char *iv, unsigned char *input_data,
 		unsigned int message_part, uint64_t *running_length_lo,
 		uint64_t *running_length_hi)
 {
-	int rc = EPERM;
+	int rc = ENODEV;
 
 	if (sha3_switch)
 		rc = s390_sha_hw(iv, input_data, input_length, output_data, output_length,

--- a/src/tests/icastats_test.c
+++ b/src/tests/icastats_test.c
@@ -337,6 +337,9 @@ static int handle_ica_error(int rc, char *message)
 		case EINVAL:
 		  V_(printf("Incorrect parameter.\n"));
 		  break;
+		case ENODEV:
+		  V_(printf("No hardware device available.\n"));
+		  break;
 		case EPERM:
 		  V_(printf("Operation not permitted by Hardware.\n"));
 		  break;

--- a/src/tests/icastats_test.c
+++ b/src/tests/icastats_test.c
@@ -813,6 +813,12 @@ void aes_tests(unsigned char *iv, unsigned char *cmac, unsigned char *ctr)
 		0xab, 0xf7, 0x15, 0x88, 0x09, 0xcf, 0x4f, 0x3c,
 
 	};
+	/* xts needs the two keys to be different (fips-build) */
+	unsigned char aes_key2[] = {
+		0x3b, 0x7e, 0x15, 0x16, 0x28, 0xae, 0xd2, 0xa6,
+		0xab, 0xf7, 0x15, 0x88, 0x09, 0xcf, 0x4f, 0x3c,
+
+	};
 
 	unsigned char tweak[] = {
 		0x72, 0xf3, 0xb0, 0x54, 0xcb, 0xdc, 0x2f, 0x9e,
@@ -922,7 +928,7 @@ void aes_tests(unsigned char *iv, unsigned char *cmac, unsigned char *ctr)
 	system("icastats -r");
 	for(mode = 1;mode >= 0;mode--){
 		rc = ica_aes_xts(input_buffer, output_buffer, DATA_LENGHT,
-				 aes_key, aes_key, AES_KEY_LEN128, tweak, mode);
+				 aes_key, aes_key2, AES_KEY_LEN128, tweak, mode);
 
 		if(rc)
 			exit(handle_ica_error(rc, "ica_aes_xts"));

--- a/src/tests/libica_aes_gcm_kma_test.c
+++ b/src/tests/libica_aes_gcm_kma_test.c
@@ -58,8 +58,8 @@ int test_gcm_kat(int iteration)
 	/* Update for encrypt */
 	rc = ica_aes_gcm_kma_update(input_data, encrypt, data_length, aad, aad_length, 1, 1, ctx);
 
-	if (rc == EPERM) {
-		VV_(printf("ica_aes_gcm returns with EPERM (%d).\n", rc));
+	if (rc == ENODEV) {
+		VV_(printf("ica_aes_gcm returns with ENODEV (%d).\n", rc));
 		VV_(printf("Operation is not permitted on this machine. Test skipped!\n"));
 		return 0;
 	}
@@ -102,8 +102,8 @@ int test_gcm_kat(int iteration)
 	/* Update for decrypt */
 	rc = ica_aes_gcm_kma_update(encrypt, decrypt, data_length, aad, aad_length, 1, 1, ctx);
 
-	if (rc == EPERM) {
-		VV_(printf("ica_aes_gcm returns with EPERM (%d).\n", rc));
+	if (rc == ENODEV) {
+		VV_(printf("ica_aes_gcm returns with ENODEV (%d).\n", rc));
 		VV_(printf("Operation is not permitted on this machine. Test skipped!\n"));
 		return 0;
 	}
@@ -209,8 +209,8 @@ int test_gcm_kat_update(int iteration)
 				ctx);
 	}
 
-	if (rc == EPERM) {
-		VV_(printf("ica_aes_gcm returns with EPERM (%d).\n", rc));
+	if (rc == ENODEV) {
+		VV_(printf("ica_aes_gcm returns with ENODEV (%d).\n", rc));
 		VV_(printf("Operation is not permitted on this machine. Test skipped!\n"));
 		return 0;
 	}
@@ -284,8 +284,8 @@ int test_gcm_kat_update(int iteration)
 				ctx);
 	}
 
-	if (rc == EPERM) {
-		VV_(printf("ica_aes_gcm returns with EPERM (%d).\n", rc));
+	if (rc == ENODEV) {
+		VV_(printf("ica_aes_gcm returns with ENODEV (%d).\n", rc));
 		VV_(printf("Operation is not permitted on this machine. Test skipped!\n"));
 		return 0;
 	}
@@ -408,8 +408,8 @@ int test_gcm_kat_update_aad(int iteration)
 				ctx);
 	}
 
-	if (rc == EPERM) {
-		VV_(printf("ica_aes_gcm returns with EPERM (%d).\n", rc));
+	if (rc == ENODEV) {
+		VV_(printf("ica_aes_gcm returns with ENODEV (%d).\n", rc));
 		VV_(printf("Operation is not permitted on this machine. Test skipped!\n"));
 		return 0;
 	}
@@ -479,8 +479,8 @@ int test_gcm_kat_update_aad(int iteration)
 				ctx);
 	}
 
-	if (rc == EPERM) {
-		VV_(printf("ica_aes_gcm returns with EPERM (%d).\n", rc));
+	if (rc == ENODEV) {
+		VV_(printf("ica_aes_gcm returns with ENODEV (%d).\n", rc));
 		VV_(printf("Operation is not permitted on this machine. Test skipped!\n"));
 		return 0;
 	}
@@ -584,8 +584,8 @@ int test_gcm_kat_update_in_place(int iteration)
 				ctx);
 	}
 
-	if (rc == EPERM) {
-		VV_(printf("ica_aes_gcm returns with EPERM (%d).\n", rc));
+	if (rc == ENODEV) {
+		VV_(printf("ica_aes_gcm returns with ENODEV (%d).\n", rc));
 		VV_(printf("Operation is not permitted on this machine. Test skipped!\n"));
 		return 0;
 	}
@@ -655,8 +655,8 @@ int test_gcm_kat_update_in_place(int iteration)
 				ctx);
 	}
 
-	if (rc == EPERM) {
-		VV_(printf("ica_aes_gcm returns with EPERM (%d).\n", rc));
+	if (rc == ENODEV) {
+		VV_(printf("ica_aes_gcm returns with ENODEV (%d).\n", rc));
 		VV_(printf("Operation is not permitted on this machine. Test skipped!\n"));
 		return 0;
 	}


### PR DESCRIPTION
Introduce a new function to set libica's fallback mode.
Slight rework for all the hw functions which do not
have fallbacks to return ENODEV. The old code used
sometimes EPERM, 1 and on some places already ENODEV.

Signed-off-by: Harald Freudenberger <freude@linux.vnet.ibm.com>