### PR TITLE
Fix icastats counter format

### DIFF
--- a/src/icastats.c
+++ b/src/icastats.c
@@ -10,7 +10,7 @@
  *             Benedikt Klotz <benedikt.klotz@de.ibm.com>
  *             Ingo Tuchscherer <ingo.tuchscherer@de.ibm.com>
  *
- * Copyright IBM Corp. 2009, 2010, 2011, 2014
+ * Copyright IBM Corp. 2009-2019
  */
 
 #include <stdio.h>
@@ -24,7 +24,7 @@
 #include "icastats.h"
 
 #define CMD_NAME "icastats"
-#define COPYRIGHT "Copyright IBM Corp. 2009, 2010, 2011, 2014."
+#define COPYRIGHT "Copyright IBM Corp. 2009-2019"
 
 void print_version(void)
 {
@@ -69,24 +69,24 @@ const char *const STATS_DESC[ICA_NUM_STATS] = {
 
 
 
-#define CELL_SIZE 10
+#define CELL_SIZE 12
 void print_stats(stats_entry_t *stats)
 {
-	printf(" function       |           hardware       |            software\n");
-	printf("----------------+--------------------------+-------------------------\n");
-	printf("                |      ENC    CRYPT   DEC  |      ENC    CRYPT   DEC \n");
-	printf("----------------+--------------------------+-------------------------\n");
+	printf(" function       |             hardware         |              software\n");
+	printf("----------------+------------------------------+-----------------------------\n");
+	printf("                |        ENC    CRYPT     DEC  |        ENC     CRYPT    DEC \n");
+	printf("----------------+------------------------------+-----------------------------\n");
 	unsigned int i;
 	for (i = 0; i < ICA_NUM_STATS; ++i){
 		if(i<=ICA_STATS_RSA_CRT){
-			printf(" %14s |      %*d          |       %*d\n",
+			printf(" %14s |        %*lu          |         %*lu\n",
 			       STATS_DESC[i],
 			       CELL_SIZE,
 			       stats[i].enc.hw,
 			       CELL_SIZE,
 			       stats[i].enc.sw);
 		} else{
-			printf(" %14s |%*d     %*d |%*d    %*d\n",
+			printf(" %14s |%*lu     %*lu |%*lu    %*lu\n",
 			       STATS_DESC[i],
 			       CELL_SIZE,
 			       stats[i].enc.hw,

--- a/src/icastats_shared.c
+++ b/src/icastats_shared.c
@@ -34,18 +34,18 @@ static stats_entry_t *stats = NULL;
 volatile int stats_shm_handle = NOT_INITIALIZED;
 
 
-static inline void atomic_add(int *x, int i)
+static inline void atomic_add(uint64_t *x, uint64_t i)
 {
-	int old;
-	int new;
-	asm volatile ("	l	%0,%2\n"
-		      "0:	lr	%1,%0\n"
-		      "	ar	%1,%3\n"
-		      "	cs	%0,%1,%2\n"
-		      "	jl	0b"
-		      :"=&d" (old), "=&d"(new), "=Q"(*x)
-		      :"d"(i), "Q"(*x)
-		      :"cc", "memory");
+    uint64_t old;
+    uint64_t new;
+    asm volatile ("   lg      %0,%2\n"
+                  "0: lgr     %1,%0\n"
+                  "   agr     %1,%3\n"
+                  "   csg     %0,%1,%2\n"
+                  "   jl      0b"
+                 :"=&d" (old), "=&d"(new), "=Q"(*x)
+                 :"d"(i), "Q"(*x)
+                 :"cc", "memory");
 }
 
 
@@ -125,7 +125,7 @@ void stats_munmap(int unlink)
  * @direction - valid values are ENCRYPT and DECRYPT
  */
 
-uint32_t stats_query(stats_fields_t field, int hardware, int direction)
+uint64_t stats_query(stats_fields_t field, int hardware, int direction)
 {
 	if (stats == NULL)
 		return 0;
@@ -277,14 +277,14 @@ void stats_increment(stats_fields_t field, int hardware, int direction)
 
 	if(direction == ENCRYPT)
 		if (hardware == ALGO_HW)
-			atomic_add((int *)&stats[field].enc.hw, 1);
+			atomic_add(&stats[field].enc.hw, 1);
 		else
-			atomic_add((int *)&stats[field].enc.sw, 1);
+			atomic_add(&stats[field].enc.sw, 1);
 	else
 		if (hardware == ALGO_HW)
-			atomic_add((int *)&stats[field].dec.hw, 1);
+			atomic_add(&stats[field].dec.hw, 1);
 		else
-			atomic_add((int *)&stats[field].dec.sw, 1);
+			atomic_add(&stats[field].dec.sw, 1);
 }
 #endif
 

--- a/src/include/icastats.h
+++ b/src/include/icastats.h
@@ -18,8 +18,8 @@
 
 
 typedef struct crypt_opts{
-	uint32_t hw;
-	uint32_t sw;
+	uint64_t hw;
+	uint64_t sw;
 } crypt_opts_t;
 
 typedef struct statis_entry {
@@ -159,7 +159,7 @@ typedef enum stats_fields {
 
 int stats_mmap(int user);
 void stats_munmap(int unlink);
-uint32_t stats_query(stats_fields_t field, int hardware, int direction);
+uint64_t stats_query(stats_fields_t field, int hardware, int direction);
 void get_stats_data(stats_entry_t *entries);
 void stats_increment(stats_fields_t field, int hardware, int direction);
 int get_stats_sum(stats_entry_t *sum);

--- a/test/icastats_test.c
+++ b/test/icastats_test.c
@@ -239,7 +239,7 @@ void check_icastats(int algo_id, char *stat)
 	char cmd[256], line[256], *p;
 	FILE *f;
 	int i, hw, rc=-1, counters=0;
-	int hwcounter1=0, hwcounter2=0, swcounter1=0, swcounter2=0;
+	uint64_t hwcounter1=0, hwcounter2=0, swcounter1=0, swcounter2=0;
 
 	hw = check_hw(algo_id);
 	if (hw < 0) return; /* unknown algo_id */
@@ -267,13 +267,13 @@ void check_icastats(int algo_id, char *stat)
 	if (!p) goto out; /* no | in the output. Wrong algo string ? */
 	p++;
 	while (isspace(*p)) p++;
-	hwcounter1 = atoi(p); /* parse 1st hw counter value */
+	hwcounter1 = atol(p); /* parse 1st hw counter value */
 	counters++;
 	while (*p && !isspace(*p)) p++; /* parse over counter value */
 	while (isspace(*p)) p++;
 	/* now either a | or another counter value follows */
 	if (isdigit(*p)) {
-		hwcounter2 = atoi(p); /* parse 2nd hw counter value */
+		hwcounter2 = atol(p); /* parse 2nd hw counter value */
 		counters++;
 		while (*p && !isspace(*p)) p++; /* parse over counter value */
 		while (isspace(*p)) p++;
@@ -285,13 +285,13 @@ void check_icastats(int algo_id, char *stat)
 	}
 	p++;
 	while (isspace(*p)) p++;
-	swcounter1 = atoi(p); /* parse 1st sw counter value */
+	swcounter1 = atol(p); /* parse 1st sw counter value */
 	counters++;
 	while (*p && !isspace(*p)) p++; /* parse over counter value */
 	while (isspace(*p)) p++;
 	/* maybe another counter value follows */
 	if (isdigit(*p)) {
-		swcounter2 = atoi(p); /* parse 2nd sw counter value */
+		swcounter2 = atol(p); /* parse 2nd sw counter value */
 		counters++;
 	}
 


### PR DESCRIPTION
icastats counters displayed negative numbers for counts
higher than 31 bits in size. Now using 64-bit unsigned values.

Signed-off-by: Joerg Schmidbauer <jschmidb@de.ibm.com>