### PR TITLE
FIPS: introduce HMAC based library integrity check

### DIFF
--- a/include/ica_api.h
+++ b/include/ica_api.h
@@ -216,7 +216,7 @@ typedef ica_adapter_handle_t ICA_ADAPTER_HANDLE;
  */
 /* Cryptographic algorithm test (KAT or pair-wise consistency test) */
 #define ICA_FIPS_CRYPTOALG	2
-/* Software/Firmware integrity test (not implemented yet) */
+/* Software/Firmware integrity test */
 #define ICA_FIPS_INTEGRITY	4
 /* Critical functions test (N/A) */
 #define ICA_FIPS_CRITICALFUNC	8

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -9,7 +9,7 @@ lib_LTLIBRARIES = libica.la
 libica_la_CFLAGS = ${AM_CFLAGS} -I${srcdir}/include -I${srcdir}/../include \
 		   -fvisibility=hidden -pthread
 libica_la_CCASFLAGS = ${AM_CFLAGS}
-libica_la_LIBADD = @LIBS@ -lrt -lcrypto
+libica_la_LIBADD = @LIBS@ -lrt -lcrypto -ldl
 libica_la_LDFLAGS = -Wl,--version-script=${srcdir}/../libica.map \
 		    -version-number ${VERSION}
 libica_la_SOURCES = ica_api.c init.c icastats_shared.c s390_rsa.c \
@@ -53,7 +53,7 @@ internal_tests_ec_internal_test_CFLAGS = ${AM_CFLAGS} -I${srcdir}/include \
 					 -DICA_INTERNAL_TEST \
 					 -DICA_INTERNAL_TEST_EC
 internal_tests_ec_internal_test_CCASFLAGS = ${AM_CFLAGS}
-internal_tests_ec_internal_test_LDADD = @LIBS@ -lrt -lcrypto -lpthread
+internal_tests_ec_internal_test_LDADD = @LIBS@ -lrt -lcrypto -lpthread -ldl
 internal_tests_ec_internal_test_SOURCES = \
 		    ica_api.c init.c icastats_shared.c s390_rsa.c \
 		    s390_crypto.c s390_ecc.c s390_prng.c s390_sha.c \

--- a/src/include/fips.h
+++ b/src/include/fips.h
@@ -27,8 +27,8 @@ extern int fips;			/* module status */
 void fips_init(void);
 
 /*
- * Powerup tests: crypto algorithm test, SW/FW integrity test (not implemented
- * yet), critical function test (no critical functions). The tests set the
+ * Powerup tests: crypto algorithm test, SW/FW integrity test, critical
+ * function test (no critical functions). The tests set the
  * corresponding status flags.
  */
 void fips_powerup_tests(void);

--- a/test/fips_test.c
+++ b/test/fips_test.c
@@ -57,6 +57,10 @@ main(void)
 		printf("Libica FIPS powerup test failed.\n");
 		rv = EXIT_FAILURE;
 	}
+	if (fips & ICA_FIPS_INTEGRITY) {
+		printf("Libica FIPS integrity check failed.\n");
+		rv = EXIT_FAILURE;
+	}
 #endif /* ICA_FIPS */
 
 	printf("OpenSSL version is '%s'.\n", OPENSSL_VERSION_TEXT);


### PR DESCRIPTION
When in FIPS mode, perform an integrity check on libica.so by calculating
an HMAC from the file contents using a static HMAC key, and comparing it
to a pre-calculated HMAC in a separate file. The HMAC key and HMAC file
may be provided by a Distributor when building the packet. The test
succeeds if the HMAC file is not present.

Signed-off-by: Joerg Schmidbauer <jschmidb@de.ibm.com>