### PR TITLE
FIPS: HMAC based library integrity check addon

### DIFF
--- a/src/fips.c
+++ b/src/fips.c
@@ -154,7 +154,7 @@ static char *make_hmac_path(const char *origpath)
 	char *path;
 	const char *fn;
 
-	path = malloc(sizeof(HMAC_PREFIX) + sizeof(HMAC_SUFFIX) + strlen(origpath) + 1);
+	path = calloc(1, sizeof(HMAC_PREFIX) + sizeof(HMAC_SUFFIX) + strlen(origpath) + 1);
 	if (path == NULL)
 		return NULL;
 
@@ -183,6 +183,9 @@ static int compute_file_hmac(const char *path, void **buf, size_t *hmaclen)
 	EVP_PKEY *pkey = NULL;
 	size_t hlen, len;
 	long keylen;
+
+	*buf = NULL;
+	*hmaclen = 0;
 
 	keybuf = OPENSSL_hexstr2buf(hmackey, &keylen);
 	pkey = EVP_PKEY_new_mac_key(EVP_PKEY_HMAC, NULL, keybuf, (int)keylen);
@@ -270,7 +273,7 @@ static int FIPSCHECK_verify(const char *path)
 	if (compute_file_hmac(path, &buf, &buflen) != 0)
 		goto end;
 
-	if (memcmp(buf, hmac_buf, hmaclen) != 0)
+	if (memcmp(buf, hmac_buf, buflen) != 0)
 		goto end;
 
 	rc = 1;

--- a/src/fips.c
+++ b/src/fips.c
@@ -245,12 +245,12 @@ static int FIPSCHECK_verify(const char *path)
 {
 	int rc = 0;
 	FILE *fp;
-	unsigned char *hmac_buf = NULL;
+	unsigned char *known_hmac = NULL;
 	long hmaclen;
 	char *hmacpath, *p;
-	char *hmac_str = NULL;
-	size_t n, buflen;
-	void *buf = NULL;
+	char *known_hmac_str = NULL;
+	size_t n, computed_hmac_len;
+	void *computed_hmac = NULL;
 
 	hmacpath = make_hmac_path(path);
 	if (hmacpath == NULL)
@@ -262,29 +262,29 @@ static int FIPSCHECK_verify(const char *path)
 		goto end;
 	}
 
-	if (getline(&hmac_str, &n, fp) <= 0)
+	if (getline(&known_hmac_str, &n, fp) <= 0)
 		goto end;
 
-	if ((p = strchr(hmac_str, '\n')) != NULL)
+	if ((p = strchr(known_hmac_str, '\n')) != NULL)
 		*p = '\0';
 
-	hmac_buf = OPENSSL_hexstr2buf(hmac_str, &hmaclen);
+	known_hmac = OPENSSL_hexstr2buf(known_hmac_str, &hmaclen);
 
-	if (compute_file_hmac(path, &buf, &buflen) != 0)
+	if (compute_file_hmac(path, &computed_hmac, &computed_hmac_len) != 0)
 		goto end;
 
-	if (memcmp(buf, hmac_buf, buflen) != 0)
+	if (memcmp(computed_hmac, known_hmac, computed_hmac_len) != 0)
 		goto end;
 
 	rc = 1;
 
 end:
 
-	free(buf);
-	free(hmac_str);
+	free(computed_hmac);
+	free(known_hmac_str);
 	free(hmacpath);
 
-	OPENSSL_free(hmac_buf);
+	OPENSSL_free(known_hmac);
 
 	if (fp)
 		fclose(fp);


### PR DESCRIPTION
Initialize path variable with nulls by using calloc instead of
malloc, improve checking of hmac length, and rename variables
to more self-explaining names.

Signed-off-by: Joerg Schmidbauer <jschmidb@de.ibm.com>