### PR TITLE
New libica version 3.7.0

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+v3.7.0
+ - [FEATURE] FIPS: Add HMAC based library integrity check
+ - [PATCH] icainfo: bugfix for RSA and EC related info for software column.
+ - [PATCH] FIPS: provide output iv in cbc-cs decrypt as required by FIPS tests
+ - [PATCH] FIPS: Fix DES and TDES key length
+ - [PATCH] icastats: Fix stats counter format
 v3.6.1
  - [PATCH] Fix x25519 and x448 handling of non-canonical values
 v3.6.0

--- a/configure.ac
+++ b/configure.ac
@@ -1,4 +1,4 @@
-AC_INIT([libica], [3.6.1], [https://github.com/opencryptoki/libica/issues],, [https://github.com/opencryptoki/libica])
+AC_INIT([libica], [3.7.0], [https://github.com/opencryptoki/libica/issues],, [https://github.com/opencryptoki/libica])
 
 # save cmdline flags
 cmdline_CFLAGS="$CFLAGS"

--- a/libica.spec
+++ b/libica.spec
@@ -1,5 +1,5 @@
 Name:          libica
-Version:       3.6.1
+Version:       3.7.0
 Release:       1%{?dist}
 Summary:       Interface library to the ICA device driver
 
@@ -62,6 +62,8 @@ rm -rf $RPM_BUILD_ROOT
 %{_includedir}/ica_api.h
 
 %changelog
+* Tue May 06 2020 Joerg Schmidbauer <jschmidb@linux.vnet.ibm.com>
+- Version v3.7.0
 * Wed Nov 13 2019 Patrick Steuer <steuer@linux.vnet.ibm.com>
 - Version v3.6.1
 * Wed Aug 28 2019 Patrick Steuer <steuer@linux.vnet.ibm.com>

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,4 +1,4 @@
-VERSION = 3:6:1
+VERSION = 3:7:0
 
 AM_CFLAGS = @FLAGS@
 


### PR DESCRIPTION
- [FEATURE] FIPS: Add HMAC based library integrity check

Signed-off-by: Joerg Schmidbauer <jschmidb@de.ibm.com>