### PR TITLE
FIPS: fix inconsistent error handling.

### DIFF
--- a/src/fips.c
+++ b/src/fips.c
@@ -295,10 +295,8 @@ static int FIPSCHECK_verify(const char *path)
 		return 0;
 
 	fp = fopen(hmacpath, "r");
-	if (fp == NULL) {
-		rc = 1;
+	if (fp == NULL)
 		goto end;
-	}
 
 	if (getline(&known_hmac_str, &n, fp) <= 0)
 		goto end;


### PR DESCRIPTION
when the HMAC file is not present/readable it is also an error.

Signed-off-by: Michal Suchanek <msuchanek@suse.de>