### PR TITLE
FIPS: enforce the hmac check

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -4,6 +4,7 @@ SUBDIRS = doc include src test
 
 dist_doc_DATA = AUTHORS ChangeLog INSTALL LICENSE README.md
 EXTRA_DIST = libica.map libica.spec
+MAJOR := `echo $(VERSION) | cut -d. -f1`
 
 coverage: check
 	@echo -e "\n-----------------";
@@ -14,3 +15,14 @@ coverage: check
 	@echo -e "libica coverage";
 	@echo -e "---------------\n";
 	cd ${top_builddir}/src && gcov .libs/*.gcda
+
+if ICA_FIPS
+install-data-hook:
+	$(INSTALL) -m 0444 ${top_builddir}/src/.libs/.libica.so.$(VERSION).hmac $(DESTDIR)$(libdir)
+	cd $(DESTDIR)$(libdir) && ln -sf .libica.so.$(VERSION).hmac .libica.so.$(MAJOR).hmac
+
+uninstall-hook:
+	rm -f $(DESTDIR)$(libdir)/.libica.so.$(MAJOR).hmac
+	rm -f $(DESTDIR)$(libdir)/.libica.so.$(VERSION).hmac
+endif
+

--- a/doc/icastats.1
+++ b/doc/icastats.1
@@ -37,7 +37,7 @@ Here is a shortened sample output:
           ...
    ECDSA Sign |             0         |             0
  ECDSA Verify |             0         |             0
-       ECKGEN |             0         |             0
+    EC Keygen |             0         |             0
        RSA-ME |             0         |             0
           ...
        RSA-ME |             0         |             0

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,6 +1,10 @@
 VERSION = 3:7:0
 
 AM_CFLAGS = @FLAGS@
+MAJOR := `echo $(VERSION) | cut -d: -f1`
+MINOR := `echo $(VERSION) | cut -d: -f2`
+PATCH := `echo $(VERSION) | cut -d: -f3`
+VERSION1 := $(MAJOR).$(MINOR).$(PATCH)
 
 # lib
 
@@ -29,6 +33,18 @@ libica_la_SOURCES = ica_api.c init.c icastats_shared.c s390_rsa.c \
 EXTRA_DIST = mp.pl
 mp.S	: mp.pl
 	./mp.pl mp.S
+
+if ICA_FIPS
+hmac-file-lnk: hmac-file
+	$(AM_V_GEN) cd ${top_builddir}/src/.libs && ln -sf .libica.so.$(VERSION1).hmac .libica.so.$(MAJOR).hmac
+
+hmac-file: libica.la
+	$(AM_V_GEN) openssl dgst -sha256 -mac hmac -macopt hexkey:00000000 ${top_builddir}/src/.libs/libica.so.$(VERSION1) | sed -e 's/^.* //' > ${top_builddir}/src/.libs/.libica.so.$(VERSION1).hmac
+
+hmac_files = hmac-file hmac-file-lnk
+
+all-local: $(hmac_files)
+endif
 
 # bin
 
@@ -69,3 +85,5 @@ internal_tests_ec_internal_test_SOURCES = \
 		    include/s390_rsa.h include/s390_sha.h include/test_vec.h \
 		    include/rng.h ../test/testcase.h
 endif
+
+.PHONY: hmac-file hmac-file-lnk

--- a/src/fips.c
+++ b/src/fips.c
@@ -296,7 +296,6 @@ static int FIPSCHECK_verify(const char *path)
 
 	fp = fopen(hmacpath, "r");
 	if (fp == NULL) {
-		rc = 1;
 		goto end;
 	}
 

--- a/src/icainfo.c
+++ b/src/icainfo.c
@@ -83,7 +83,7 @@ static struct crypt_pair crypt_map[] = {
 	{"ECDH", EC_DH},
 	{"ECDSA Sign", EC_DSA_SIGN},
 	{"ECDSA Verify", EC_DSA_VERIFY},
-	{"ECKGEN", EC_KGEN},
+	{"EC Keygen", EC_KGEN},
 	{"Ed25519 Keygen", ED25519_KEYGEN},
 	{"Ed25519 Sign", ED25519_SIGN},
 	{"Ed25519 Verify", ED25519_VERIFY},

--- a/src/include/icastats.h
+++ b/src/include/icastats.h
@@ -110,7 +110,7 @@ typedef enum stats_fields {
 	"ECDH",         \
 	"ECDSA Sign",   \
 	"ECDSA Verify", \
-	"ECKGEN",       \
+	"EC Keygen",    \
 	"Ed25519 Keygen",\
 	"Ed25519 Sign", \
 	"Ed25519 Verify",\

--- a/src/s390_ecc.c
+++ b/src/s390_ecc.c
@@ -739,7 +739,7 @@ unsigned int ecdh_hw(ica_adapter_handle_t adapter_handle,
 		const ICA_EC_KEY *privkey_A, const ICA_EC_KEY *pubkey_B,
 		unsigned char *z)
 {
-	uint8_t *buf;
+	uint8_t *buf = NULL;
 	size_t len;
 	int rc;
 	struct ica_xcRB xcrb;
@@ -760,8 +760,10 @@ unsigned int ecdh_hw(ica_adapter_handle_t adapter_handle,
 		return EIO;
 
 	reply_p = make_ecdh_request(privkey_A, pubkey_B, &xcrb, &buf, &len);
-	if (!reply_p)
-		return EIO;
+	if (!reply_p) {
+		rc = EIO;
+		goto ret;
+	}
 
 	rc = ioctl(adapter_handle, ZSECSENDCPRB, xcrb);
 	if (rc != 0) {
@@ -777,8 +779,10 @@ unsigned int ecdh_hw(ica_adapter_handle_t adapter_handle,
 	memcpy(z, reply_p->raw_z_value, privlen);
 	rc = 0;
 ret:
-	OPENSSL_cleanse(buf, len);
-	free(buf);
+	if (buf) {
+		OPENSSL_cleanse(buf, len);
+		free(buf);
+	}
 	return rc;
 }
 
@@ -1125,7 +1129,7 @@ unsigned int ecdsa_sign_hw(ica_adapter_handle_t adapter_handle,
 		const ICA_EC_KEY *privkey, const unsigned char *hash, unsigned int hash_length,
 		unsigned char *signature)
 {
-	uint8_t *buf;
+	uint8_t *buf = NULL;
 	size_t len;
 	int rc;
 	struct ica_xcRB xcrb;
@@ -1153,8 +1157,10 @@ unsigned int ecdsa_sign_hw(ica_adapter_handle_t adapter_handle,
 
 	reply_p = make_ecdsa_sign_request((const ICA_EC_KEY*)privkey,
 			X, Y, hash, hash_length, &xcrb, &buf, &len);
-	if (!reply_p)
-		return EIO;
+	if (!reply_p) {
+		rc = EIO;
+		goto ret;
+	}
 
 	rc = ioctl(adapter_handle, ZSECSENDCPRB, xcrb);
 	if (rc != 0) {
@@ -1170,8 +1176,10 @@ unsigned int ecdsa_sign_hw(ica_adapter_handle_t adapter_handle,
 	memcpy(signature, reply_p->signature, reply_p->vud_len-8);
 	rc = 0;
 ret:
-	OPENSSL_cleanse(buf, len);
-	free(buf);
+	if (buf) {
+		OPENSSL_cleanse(buf, len);
+		free(buf);
+	}
 	return rc;
 }
 
@@ -1582,7 +1590,7 @@ unsigned int ecdsa_verify_hw(ica_adapter_handle_t adapter_handle,
 		const ICA_EC_KEY *pubkey, const unsigned char *hash, unsigned int hash_length,
 		const unsigned char *signature)
 {
-	uint8_t *buf;
+	uint8_t *buf = NULL;
 	size_t len;
 	int rc;
 	struct ica_xcRB xcrb;
@@ -1602,8 +1610,10 @@ unsigned int ecdsa_verify_hw(ica_adapter_handle_t adapter_handle,
 
 	reply_p = make_ecdsa_verify_request(pubkey, hash, hash_length,
 					    signature, &xcrb, &buf, &len);
-	if (!reply_p)
-		return EIO;
+	if (!reply_p) {
+		rc = EIO;
+		goto ret;
+	}
 
 	rc = ioctl(adapter_handle, ZSECSENDCPRB, xcrb);
 	if (rc != 0) {
@@ -1625,8 +1635,10 @@ unsigned int ecdsa_verify_hw(ica_adapter_handle_t adapter_handle,
 
 	rc = 0;
 ret:
-	OPENSSL_cleanse(buf, len);
-	free(buf);
+	if (buf) {
+		OPENSSL_cleanse(buf, len);
+		free(buf);
+	}
 	return rc;
 }
 
@@ -1940,7 +1952,7 @@ static int eckeygen_cpacf(ICA_EC_KEY *key)
  */
 unsigned int eckeygen_hw(ica_adapter_handle_t adapter_handle, ICA_EC_KEY *key)
 {
-	uint8_t *buf;
+	uint8_t *buf = NULL;
 	size_t len;
 	int rc;
 	struct ica_xcRB xcrb;
@@ -1959,8 +1971,10 @@ unsigned int eckeygen_hw(ica_adapter_handle_t adapter_handle, ICA_EC_KEY *key)
 		return ENODEV;
 
 	reply_p = make_eckeygen_request(key, &xcrb, &buf, &len);
-	if (!reply_p)
-		return EIO;
+	if (!reply_p) {
+		rc = EIO;
+		goto ret;
+	}
 
 	rc = ioctl(adapter_handle, ZSECSENDCPRB, xcrb);
 	if (rc != 0) {
@@ -1985,8 +1999,10 @@ unsigned int eckeygen_hw(ica_adapter_handle_t adapter_handle, ICA_EC_KEY *key)
 	memcpy(key->X, (char*)pub_p->pubkey, 2*privlen);
 	rc = 0;
 ret:
-	OPENSSL_cleanse(buf, len);
-	free(buf);
+	if (buf) {
+		OPENSSL_cleanse(buf, len);
+		free(buf);
+	}
 	return rc;
 }
 


### PR DESCRIPTION
When in FIPS mode, the .hmac file is now created during make and its existence
is enforced by changing the check in routine FIPSCHECK_verify to fail if it
cannot be opened.

This should make it easier for distributors to adapt the lib integrity check for their
distros, just by changing the static hmac key in fips.c and Makefile.am.

Notes:

- The openssl commandline expects a hex key
- The "check: all" in Makefile.am is necessary to create the .hmac file before running the internal tests when doing a "make check" without a "make all" before
- explicitly removing the .hmac file from src/.libs during "make uninstall" is not necessary, as the whole .libs directory is removed