### PR TITLE
FIPS BUILD: check for openssl app

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -62,6 +62,12 @@ AM_CONDITIONAL(ICA_FIPS, test x$enable_fips = xyes)
 if test "x$enable_fips" = xyes; then
 	FLAGS="$FLAGS -DICA_FIPS"
 	AC_MSG_RESULT([*** Building libica-fips at user request ***])
+        AC_CHECK_PROG([openssl_var],[openssl],[yes],[no])
+
+        if test "x$openssl_var" != xyes; then
+              AC_MSG_ERROR([Missing openssl binary application required for FIPS build])
+        fi
+
 fi
 
 dnl --- enable_sanitizer


### PR DESCRIPTION
The openssl binary is needed for FIPS build to compute the HMAC.  Since the
computation of the HMAC calls openssl inside a piped command, a missing
openssl binary will not even produce a build error.  Instead, the HMAC file
will be empty and the library will not load in FIPS mode.

Instead of build error, lets make this a configure error and check during
configuration that the binary "openssl" is available.

Signed-off-by: Juergen Christ <jchrist@linux.ibm.com>