### PR TITLE
Misc ECC fixes

### DIFF
--- a/include/ica_api.h
+++ b/include/ica_api.h
@@ -965,7 +965,7 @@ typedef struct ec_key_t ICA_EC_KEY;
  * Also an ECDSA signature has twice the length of D.
  *
  * @return Pointer to opaque ICA_EC_KEY structure if success.
- * NULL if no memory could be allocated, or an unsupported nid is specified.
+ * NULL if no memory could be allocated.
  */
 ICA_EXPORT
 ICA_EC_KEY* ica_ec_key_new(unsigned int nid, unsigned int *privlen);
@@ -990,6 +990,7 @@ ICA_EC_KEY* ica_ec_key_new(unsigned int nid, unsigned int *privlen);
  * ICA_EC_KEY object.
  *
  * @return 0 if success
+ * EPERM if the EC curve is not supported in this environment
  * EINVAL if at least one invalid parameter is given.
  */
 ICA_EXPORT
@@ -1006,6 +1007,7 @@ int ica_ec_key_init(const unsigned char *X, const unsigned char *Y,
  * Pointer to a previously allocated ICA_EC_KEY object.
  *
  * @return 0 if success
+ * EPERM if the EC curve is not supported in this environment
  * EINVAL if at least one invalid parameter is given.
  * ENOMEM if memeory could not be allocated.
  * EIO if an internal processing error occurred.
@@ -1034,6 +1036,7 @@ int ica_ec_key_generate(ica_adapter_handle_t adapter_handle, ICA_EC_KEY *key);
  * both keys have the same lengths of D, and (X,Y).
  *
  * @return 0 if success
+ * EPERM if the EC curve is not supported in this environment
  * EINVAL if at least one invalid parameter is given.
  * EIO if an internal processing error occurred.
  */

--- a/include/ica_api.h
+++ b/include/ica_api.h
@@ -758,7 +758,7 @@ unsigned int ica_sha384(unsigned int message_part,
  * @param sha512_context
  * Pointer to the SHA-512 context structure used to store intermediate values
  * needed when chaining is used. The contents are ignored for message part
- * SHA_MSG_PART_ONLY and SHA_MSG_PART_FIRST. This structuremust
+ * SHA_MSG_PART_ONLY and SHA_MSG_PART_FIRST. This structure must
  * contain the returned value of the preceding call to ica_sha512 for message
  * part SHA_MSG_PART_MIDDLE and SHA_MSG_PART_FINAL. For message part
  * SHA_MSG_PART_FIRST and SHA_MSG_PART_FINAL, the returned value can
@@ -1009,7 +1009,7 @@ int ica_ec_key_init(const unsigned char *X, const unsigned char *Y,
  * @return 0 if success
  * EPERM if the EC curve is not supported in this environment
  * EINVAL if at least one invalid parameter is given.
- * ENOMEM if memeory could not be allocated.
+ * ENOMEM if memory could not be allocated.
  * EIO if an internal processing error occurred.
  */
 ICA_EXPORT
@@ -1280,7 +1280,7 @@ int ica_ed448_ctx_del(ICA_ED448_CTX **ctx);
  * @param public_key
  * Pointer to where the generated public key is to be placed. If the exponent
  * element in the public key is not set, it will be randomly generated. A not
- * well chosen exponent may result in the program loooping endlessly. Common
+ * well chosen exponent may result in the program looping endlessly. Common
  * public exponents are 3 and 65537.
  * @param private_key
  * Pointer to where the generated private key in modulus/exponent format is to
@@ -1308,7 +1308,7 @@ unsigned int ica_rsa_key_generate_mod_expo(ica_adapter_handle_t adapter_handle,
  * @param public_key
  * Pointer to where the generated public key is to be placed. If the exponent
  * element in the public key is not set, it will be randomly generated. A not
- * well chosen exponent may result in the program loooping endlessly. Common
+ * well chosen exponent may result in the program looping endlessly. Common
  * public exponents are 3 and 65537.
  * @param private_key
  * Pointer to where the generated private key in CRT format is to be placed.
@@ -2006,7 +2006,7 @@ unsigned int ica_des_cmac(const unsigned char *message, unsigned long message_le
  * the Block Cipher Based Message Authentication Code (CMAC) mode as described
  * in NIST Special Publication 800-38B.
  * ica_des_cmc_intermediate and ica_des_cmac_last can be used when the message
- * to be authenticated or to be verfied using CMAC is supplied in multiple
+ * to be authenticated or to be verified using CMAC is supplied in multiple
  * chunks. ica_des_cmac_intermediate is used to process all but the last
  * chunk. All message chunks to preprocessed by ica_des_cmac_intermediate
  * must have a size that is a multiple of the cipher block size (i.e a
@@ -2190,7 +2190,7 @@ unsigned int ica_3des_cbc(const unsigned char *in_data, unsigned char *out_data,
  * message consisting of multiple chunks where all but the last chunk are
  * encrypted or decrypted by chained calls to ica_3des_cbc and the resulting
  * iv of the last call to ica_3des_cbc is fed into the iv of the
- * ica_3des_cbc_cs call provided the chunc is greater than cipher block size
+ * ica_3des_cbc_cs call provided the chunk is greater than cipher block size
  * (greater than 8 bytes for 3DES).
  *
  * Required HW Support
@@ -2443,7 +2443,7 @@ unsigned int ica_3des_ofb(const unsigned char *in_data, unsigned char *out_data,
 
 /**
  * Authenticate data or verify the authenticity of data with an 3DES key
- * using the Block Cipher Based Message Authetication Code (CMAC) mode as
+ * using the Block Cipher Based Message Authentication Code (CMAC) mode as
  * described in NIST Special Publication 800-38B.
  * ica_3des_cmac can be used to authenticate or verify the authenticity of a
  * complete message.
@@ -2494,7 +2494,7 @@ unsigned int ica_3des_cmac(const unsigned char *message, unsigned long message_l
  * the Block Cipher Based Message Authentication Code (CMAC) mode as described
  * in NIST Special Publication 800-38B.
  * ica_3des_cmc_intermediate and ica_3des_cmac_last can be used when the
- * message to be authenticated or to be verfied using CMAC is supplied in
+ * message to be authenticated or to be verified using CMAC is supplied in
  * multiple chunks. ica_3des_cmac_intermediate is used to process all but the
  * last chunk. All message chunks to preprocessed by
  * ica_3des_cmac_intermediate must have a size that is a multiple of the
@@ -2656,7 +2656,7 @@ unsigned int ica_aes_ecb(const unsigned char *in_data, unsigned char *out_data,
  * AES-128, AES-192 and AES-256 respectively. Therefore, you can use the
  * macros: AES_KEY_LEN128, AES_KEY_LEN192, and AES_KEY_LEN256.
  * @param iv
- * Pointer to a valid initialization vector of size chipher block size. This
+ * Pointer to a valid initialization vector of size cipher block size. This
  * vector will be overwritten during the function. The result value in iv may
  * be used as initialization vector for a chained ica_aes_cbc call with the
  * same key.
@@ -3014,7 +3014,7 @@ unsigned int ica_aes_cmac(const unsigned char *message, unsigned long message_le
  * the Block Cipher Based Message Authentication Code (CMAC) mode as described
  * in NIST Special Publication 800-38B.
  * ica_aes_cmc_intermediate and ica_aes_cmac_last can be used when the message
- * to be authenticated or to be verfied using CMAC is supplied in multiple
+ * to be authenticated or to be verified using CMAC is supplied in multiple
  * chunks. ica_aes_cmac_intermediate is used to process all but the last
  * chunk. All message chunks to preprocessed by ica_aes_cmac_intermediate
  * must have a size that is a multiple of the cipher block size (i.e. a
@@ -3545,7 +3545,7 @@ int ica_aes_gcm_kma_get_tag(unsigned char *tag, unsigned int tag_length,
 		const kma_ctx* ctx);
 
 /**
- * Verify if the specifed known authentication tag is identical to the
+ * Verify if the specified known authentication tag is identical to the
  * calculated tag after a decryption process.
  *
  * @param known_tag
@@ -3734,7 +3734,7 @@ int ica_drbg_instantiate(ica_drbg_t **sh,
  * (reseed a DRBG instantiation)
  *
  * @sh: State Handle. Identifies the DRBG instantiation to be reseeded.
- * @pr: Prediciton Resistance request. Indicates whether or not prediction
+ * @pr: Prediction Resistance request. Indicates whether or not prediction
  * resistance is required.
  * @add: ADDitional input: An optional input. NULL indicates that no additional
  * input is used.
@@ -3761,7 +3761,7 @@ int ica_drbg_reseed(ica_drbg_t *sh,
  * bytes are requested.
  * @sec: requested SECurity strength: Minimum bits of security that the
  * generated pseudorandom bytes SHALL offer.
- * @pr: Prediciton Resistance request. Indicates whether or not prediction
+ * @pr: Prediction Resistance request. Indicates whether or not prediction
  * resistance is required.
  * @add: ADDitional input. An optional input. NULL indicates that no additional input
  * is used.
@@ -3790,7 +3790,7 @@ int ica_drbg_generate(ica_drbg_t *sh,
 
 /*
  * Uninstantiate function
- * (destroy an existing DRBG instiantiation)
+ * (destroy an existing DRBG instantiation)
  *
  * @sh: State Handle pointer. The corresponding DRBG instantiation is destroyed
  * and the state handle is set to NULL (invalid).

--- a/src/ica_api.c
+++ b/src/ica_api.c
@@ -1338,6 +1338,8 @@ int ica_ec_key_init(const unsigned char *X, const unsigned char *Y,
 #ifdef ICA_FIPS
 	if (fips >> 1)
 		return EACCES;
+	if (!curve_supported_via_openssl(key->nid))
+		return EPERM;
 #endif /* ICA_FIPS */
 
 	/* check for obvious errors in parms */
@@ -1378,6 +1380,8 @@ int ica_ec_key_generate(ica_adapter_handle_t adapter_handle, ICA_EC_KEY *key)
 #ifdef ICA_FIPS
 	if (fips >> 1)
 		return EACCES;
+	if (!curve_supported_via_openssl(key->nid))
+		return EPERM;
 #endif /* ICA_FIPS */
 
 	/* check for obvious errors in parms */
@@ -1430,6 +1434,8 @@ int ica_ecdh_derive_secret(ica_adapter_handle_t adapter_handle,
 #ifdef ICA_FIPS
 	if (fips >> 1)
 		return EACCES;
+	if (privkey_A != NULL && !curve_supported_via_openssl(privkey_A->nid))
+		return EPERM;
 #endif /* ICA_FIPS */
 
 	/* check for obvious errors in parms */

--- a/src/ica_api.c
+++ b/src/ica_api.c
@@ -1337,7 +1337,7 @@ ICA_EC_KEY* ica_ec_key_new(unsigned int nid, unsigned int *privlen)
 int ica_ec_key_init(const unsigned char *X, const unsigned char *Y,
 		const unsigned char *D, ICA_EC_KEY *key)
 {
-	unsigned int privlen = privlen_from_nid(key->nid);
+	unsigned int privlen;
 
 #ifdef ICA_FIPS
 	if (fips >> 1)
@@ -1350,6 +1350,8 @@ int ica_ec_key_init(const unsigned char *X, const unsigned char *Y,
 
 	if ((X == NULL && Y != NULL) || (X != NULL && Y == NULL))
 		return EINVAL;
+
+	privlen = privlen_from_nid(key->nid);
 
 	if (X != NULL && Y != NULL) {
 		memcpy(key->X, X, privlen);
@@ -1411,7 +1413,7 @@ int ica_ecdh_derive_secret(ica_adapter_handle_t adapter_handle,
 		unsigned char *z, unsigned int z_length)
 {
 	int hardware, rc;
-	unsigned int privlen = privlen_from_nid(privkey_A->nid);
+	unsigned int privlen;
 	unsigned int icapath = 0;
 
 #ifdef ICA_FIPS
@@ -1420,6 +1422,10 @@ int ica_ecdh_derive_secret(ica_adapter_handle_t adapter_handle,
 #endif /* ICA_FIPS */
 
 	/* check for obvious errors in parms */
+	if (privkey_A == NULL || pubkey_B == NULL)
+		return EINVAL;
+
+	privlen = privlen_from_nid(privkey_A->nid);
 	if (z == NULL || z_length < privlen || privkey_A->nid != pubkey_B->nid)
 		return EINVAL;
 
@@ -1458,7 +1464,7 @@ int ica_ecdsa_sign(ica_adapter_handle_t adapter_handle,
 		unsigned char *signature, unsigned int signature_length)
 {
 	int hardware, rc;
-	unsigned int privlen = privlen_from_nid(privkey->nid);
+	unsigned int privlen;
 	unsigned int icapath = 0;
 
 #ifdef ICA_FIPS
@@ -1467,7 +1473,11 @@ int ica_ecdsa_sign(ica_adapter_handle_t adapter_handle,
 #endif /* ICA_FIPS */
 
 	/* check for obvious errors in parms */
-	if (privkey == NULL || hash == NULL || !hash_length_valid(hash_length) ||
+	if (privkey == NULL)
+		return EINVAL;
+
+	privlen = privlen_from_nid(privkey->nid);
+	if (hash == NULL || !hash_length_valid(hash_length) ||
 		signature == NULL || signature_length < 2*privlen)
 		return EINVAL;
 
@@ -1506,7 +1516,7 @@ int ica_ecdsa_verify(ica_adapter_handle_t adapter_handle,
 		const unsigned char *signature, unsigned int signature_length)
 {
 	int hardware, rc;
-	unsigned int privlen = privlen_from_nid(pubkey->nid);
+	unsigned int privlen;
 	unsigned int icapath = 0;
 
 #ifdef ICA_FIPS
@@ -1515,7 +1525,11 @@ int ica_ecdsa_verify(ica_adapter_handle_t adapter_handle,
 #endif /* ICA_FIPS */
 
 	/* check for obvious errors in parms */
-	if (pubkey == NULL || hash == NULL || !hash_length_valid(hash_length) ||
+	if (pubkey == NULL)
+		return EINVAL;
+
+	privlen = privlen_from_nid(pubkey->nid);
+	if (hash == NULL || !hash_length_valid(hash_length) ||
 		signature == NULL || signature_length < 2*privlen)
 		return EINVAL;
 

--- a/src/s390_ecc.c
+++ b/src/s390_ecc.c
@@ -775,7 +775,8 @@ unsigned int ecdh_hw(ica_adapter_handle_t adapter_handle,
 			return rc;
 	}
 
-	if (!ecc_via_online_card)
+	if (privkey_A->nid != pubkey_B->nid ||
+		!curve_supported_via_online_card(privkey_A->nid))
 		return ENODEV;
 
 	if (adapter_handle == DRIVER_NOT_LOADED)
@@ -1177,7 +1178,7 @@ unsigned int ecdsa_sign_hw(ica_adapter_handle_t adapter_handle,
 			return rc;
 	}
 
-	if (!ecc_via_online_card)
+	if (!curve_supported_via_online_card(privkey->nid))
 		return ENODEV;
 
 	if (adapter_handle == DRIVER_NOT_LOADED)
@@ -1645,7 +1646,7 @@ unsigned int ecdsa_verify_hw(ica_adapter_handle_t adapter_handle,
 			return rc;
 	}
 
-	if (!ecc_via_online_card)
+	if (!curve_supported_via_online_card(pubkey->nid))
 		return ENODEV;
 
 	if (adapter_handle == DRIVER_NOT_LOADED)
@@ -2021,7 +2022,7 @@ unsigned int eckeygen_hw(ica_adapter_handle_t adapter_handle, ICA_EC_KEY *key)
 			return rc;
 	}
 
-	if (!ecc_via_online_card)
+	if (!curve_supported_via_online_card(key->nid))
 		return ENODEV;
 
 	reply_p = make_eckeygen_request(key, &xcrb, &buf, &len);

--- a/src/s390_ecc.c
+++ b/src/s390_ecc.c
@@ -121,6 +121,10 @@ static EC_KEY *make_eckey(int nid, const unsigned char *p, size_t plen)
 	if (!EC_KEY_set_public_key(k, pub)) {
 		goto err;
 	}
+
+	if (!EC_KEY_check_key(k)) {
+		goto err;
+	}
 	ok = 1;
 
 err:
@@ -170,6 +174,10 @@ static EC_KEY *make_public_eckey(int nid, BIGNUM *x, BIGNUM *y, size_t plen)
 
 	if (!EC_KEY_set_public_key(k, pub))
 		goto err;
+
+	if (!EC_KEY_check_key(k))
+		goto err;
+
 	ok = 1;
 
 err:

--- a/test/ecdh_test.c
+++ b/test/ecdh_test.c
@@ -336,14 +336,40 @@ int main(int argc, char **argv)
 		memset(shared_secret, 0, sizeof(shared_secret));
 
 		eckey_A = ica_ec_key_new(ecdh_kats[i].nid, &privlen);
+		if (!eckey_A)
+			continue;
+
 		rc = ica_ec_key_init(ecdh_kats[i].xa, ecdh_kats[i].ya, ecdh_kats[i].da, eckey_A);
+		if (rc != 0) {
+			if (rc == EPERM) {
+				V_(printf("Curve %d not supported on this system, skipping ...\n", ecdh_kats[i].nid));
+				continue;
+			} else {
+				V_(printf("Failed to initialize key for nid %d, rc=%i.\n", ecdh_kats[i].nid, rc));
+				errors++;
+				continue;
+			}
+		}
 
 		eckey_B = ica_ec_key_new(ecdh_kats[i].nid, &privlen);
+		if (!eckey_B)
+			continue;
+
 		rc = ica_ec_key_init(ecdh_kats[i].xb, ecdh_kats[i].yb, ecdh_kats[i].db, eckey_B);
+		if (rc != 0) {
+			if (rc == EPERM) {
+				V_(printf("Curve %d not supported on this system, skipping ...\n", ecdh_kats[i].nid));
+				continue;
+			} else {
+				V_(printf("Failed to initialize key for nid %d, rc=%i.\n", ecdh_kats[i].nid, rc));
+				errors++;
+				continue;
+			}
+		}
 
 		for (j = 0; j < NUM_HW_SW_TESTS; j++) {
 
-			if (is_supported_openssl_curve(ecdh_kats[i].nid) || (getenv_icapath() == 2))
+			if (can_toggle(ecdh_kats[i].nid))
 				toggle_env_icapath();
 
 			VV_(printf("  performing test with ICAPATH=%d \n", getenv_icapath()));

--- a/test/ecdh_test.c
+++ b/test/ecdh_test.c
@@ -309,7 +309,7 @@ int main(int argc, char **argv)
 	set_verbosity(argc, argv);
 
 	if (!ecc_available()) {
-		printf("Skipping EC keygen test, because the required HW"
+		printf("Skipping ECDH test, because the required HW"
 		       " is not available on this machine.\n");
 		return TEST_SKIP;
 	}

--- a/test/ecdsa_test.c
+++ b/test/ecdsa_test.c
@@ -195,7 +195,7 @@ int main(int argc, char **argv)
 	set_verbosity(argc, argv);
 
 	if (!ecc_available()) {
-		printf("Skipping EC keygen test, because the required HW"
+		printf("Skipping ECDSA test, because the required HW"
 		       " is not available on this machine.\n");
 		return TEST_SKIP;
 	}


### PR DESCRIPTION
This pr provides several fixes for EC support in libica and addresses opencryptoki issue #404: Libica must check at key generate/init/derive if the EC curve is supported. It also adds openssl based EC key checking to prevent against initializing with invalid/corrupted EC key parts. Libica EC tests are adapted to the newly introduced rcs to skip tests if curves are not supported.