### PR TITLE
buffer must be freed with OPENSSL_free()

### DIFF
--- a/src/fips.c
+++ b/src/fips.c
@@ -288,7 +288,7 @@ end:
 	if (pkey != NULL)
 		EVP_PKEY_free(pkey);
 
-	free(keybuf);
+	OPENSSL_free(keybuf);
 	EVP_MD_CTX_destroy(mdctx);
 	if (fp)
 		fclose(fp);


### PR DESCRIPTION
`OPENSSL_hexstr2buf()` allocates the output buffer using `OPENSSL_malloc()`
and it means the buffer must be freed with `OPENSSL_free()`. Usually it's
not a problem, but an application can pass its own malloc/free
implementation to OpenSSL and the allocation/de-allocation functions must
match.

With ibmca engine installed and configured we have experienced a crash
in DNS related tools (`host`, `dig`, ...) in RHEL, because they provide
their own malloc/free.

````
[root@ibm-z-110 ~]# gdb /usr/bin/host
GNU gdb (GDB) Red Hat Enterprise Linux 8.2-15.el8
(gdb) set args localhost
(gdb) run
Starting program: /usr/bin/host localhost
[Thread debugging using libthread_db enabled]
Using host libthread_db library "/lib64/libthread_db.so.1".
[New Thread 0x3fffc67f910 (LWP 65794)]
[New Thread 0x3fffbe7e910 (LWP 65795)]
[New Thread 0x3fffb67d910 (LWP 65796)]
free(): invalid pointer

Thread 1 "host" received signal SIGABRT, Aborted.
0x000003fffccbe9e4 in raise () from /lib64/libc.so.6
(gdb) where
0  0x000003fffccbe9e4 in raise () from /lib64/libc.so.6
1  0x000003fffcca3218 in abort () from /lib64/libc.so.6
2  0x000003fffcd0279c in __libc_message () from /lib64/libc.so.6
3  0x000003fffcd0a348 in malloc_printerr () from /lib64/libc.so.6
4  0x000003fffcd0bd2a in _int_free () from /lib64/libc.so.6
5  0x000003fffada7d9c in compute_file_hmac (hmaclen=<optimized out>, buf=<optimized out>, path=<optimized out>) at fips.c:291
6  FIPSCHECK_verify (path=<optimized out>) at fips.c:333
7  fips_lib_integrity_check () at fips.c:417
8  0x000003fffadaa070 in fips_powerup_tests () at fips.c:460
9  0x000003fffad89ea4 in icainit () at init.c:97
10 0x000003fffdf9028e in call_init.part () from /lib/ld64.so.1
11 0x000003fffdf9039c in _dl_init () from /lib/ld64.so.1
12 0x000003fffcdbfc98 in _dl_catch_exception () from /lib64/libc.so.6
13 0x000003fffdf94bc6 in dl_open_worker () from /lib/ld64.so.1
14 0x000003fffcdbfc1e in _dl_catch_exception () from /lib64/libc.so.6
15 0x000003fffdf94364 in _dl_open () from /lib/ld64.so.1
16 0x000003fffd30114e in dlopen_doit () from /lib64/libdl.so.2
17 0x000003fffcdbfc1e in _dl_catch_exception () from /lib64/libc.so.6
18 0x000003fffcdbfd36 in _dl_catch_error () from /lib64/libc.so.6
19 0x000003fffd301910 in _dlerror_run () from /lib64/libdl.so.2
20 0x000003fffd3011d8 in dlopen@@GLIBC_2.2 () from /lib64/libdl.so.2
21 0x000003fffdf05f70 in ibmca_init () from /usr/lib64/engines-1.1/ibmca.so
22 0x000003fffd50dcbe in engine_unlocked_init () from /lib64/libcrypto.so.1.1
23 0x000003fffd50de4e in ENGINE_init () from /lib64/libcrypto.so.1.1
24 0x000003fffd50bfae in int_engine_init () from /lib64/libcrypto.so.1.1
25 0x000003fffd50c406 in int_engine_module_init () from /lib64/libcrypto.so.1.1
26 0x000003fffd4d21ec in CONF_modules_load () from /lib64/libcrypto.so.1.1
27 0x000003fffd4d2850 in CONF_modules_load_file () from /lib64/libcrypto.so.1.1
28 0x000003fffde2b02c in dst.openssl_init () from /lib64/libdns.so.1112
29 0x000003fffde32b54 in dst_lib_init2 () from /lib64/libdns.so.1112
30 0x000002aa0000f728 in setup_libs ()
31 0x000002aa00009bfa in main ()
````

Signed-off-by: Dan Horák <dan@danny.cz>