### PR TITLE
TESTCASES: add test for libica-cex

### DIFF
--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -2,6 +2,7 @@ TESTS = \
 fips_test \
 icastats_test.sh \
 get_functionlist_test \
+get_functionlist_cex_test \
 get_version_test \
 rng_test \
 drbg_test \
@@ -70,6 +71,9 @@ TESTS_ENVIRONMENT = export LD_LIBRARY_PATH=${builddir}/../src/.libs/ \
 AM_CFLAGS = @FLAGS@ -I${srcdir}/../include/ -I${srcdir}/../src/include/
 LDADD = @LIBS@ ${top_builddir}/src/.libs/libica.so -lcrypto -lpthread
 
+get_functionlist_cex_test_SOURCES = get_functionlist_cex_test.c 
+get_functionlist_cex_test_LDADD = @LIBS@ ${top_builddir}/src/.libs/libica-cex.so -lcrypto -lpthread
+
 check_PROGRAMS = fips_test icastats_test get_functionlist_test \
 get_version_test rng_test drbg_test drbg_birthdays_test des_test \
 des_ecb_test des_cbc_test des_ctr_test des_cfb_test des_ofb_test \
@@ -80,7 +84,7 @@ aes_gcm_test aes_gcm_kma_test cbccs_test ccm_test cmac_test sha_test \
 sha1_test sha256_test sha3_224_test sha3_256_test sha3_384_test \
 sha3_512_test shake_128_test shake_256_test rsa_keygen_test \
 rsa_key_check_test rsa_test ec_keygen_test ecdh_test ecdsa_test mp_test \
-eddsa_test x_test
+eddsa_test x_test get_functionlist_cex_test
 
 EXTRA_DIST = testdata testcase.h rsa_test.h aes_gcm_test.h ecdsa1_test.sh \
 sha2_test.sh ecdh1_test.sh ecdsa2_test.sh ecdh2_test.sh \

--- a/test/get_functionlist_cex_test.c
+++ b/test/get_functionlist_cex_test.c
@@ -1,0 +1,98 @@
+/* This program is released under the Common Public License V1.0
+ *
+ * You should have received a copy of Common Public License V1.0 along with
+ * with this program.
+ */
+
+/* Copyright IBM Corp. 2021 */
+
+/*
+ * Test program for libica-cex API call ica_get_functionlist().
+ *
+ * Test 1: invalid input.
+ * Test 2: Valid input.
+ */
+#include <stdio.h>
+#include <stdlib.h>
+#include <errno.h>
+#include "ica_api.h"
+#include <string.h>
+#include "testcase.h"
+
+/**
+ * For libica-cex, all CPACF-related functions and software fallbacks are
+ * unavailable. Only RSA-ME, RSA-CRT, ECDH, ECDSA, and EC keygen may be
+ * available via a CCA card. As we don't check for a CCA card here, just
+ * skip these.
+ */
+int cex_check_ok(libica_func_list_element func)
+{
+	switch (func.mech_mode_id) {
+	case RSA_ME:
+	case RSA_CRT:
+	case EC_DH:
+	case EC_DSA_SIGN:
+	case EC_DSA_VERIFY:
+	case EC_KGEN:
+		return 1;
+		break;
+	default:
+		if (func.flags != 0)
+			return 0;
+		break;
+	}
+
+	return 1;
+}
+
+int main(int argc, char **argv)
+{
+	libica_func_list_element* libica_func_list;
+	int rc;
+	int failed = 0;
+	unsigned int count, x;
+
+	set_verbosity(argc, argv);
+
+	//========== Test#1 good case ============
+	V_(printf("Testing libica-cex API ica_get_functionlist().\n"));
+	rc = ica_get_functionlist(NULL, &count);
+	if (rc) {
+		V_(printf("ica_get_functionlist for libica-cex failed with rc=%02x\n", rc));
+		return TEST_FAIL;
+	}
+	V_(printf("Retrieved number of elements: %d\n", count));
+
+	libica_func_list = malloc(sizeof(libica_func_list_element) * count);
+	rc = ica_get_functionlist(libica_func_list, &count);
+	if (rc) {
+		V_(printf("Retrieving function list for libica-cex failed with rc=%02x\n", rc));
+		failed++;
+	} else {
+		for (x = 0; x < count; x++) {
+			V_(printf("ID: %d Flags: %d Property: %d\n",
+				libica_func_list[x].mech_mode_id,
+				libica_func_list[x].flags, libica_func_list[x].property));
+			if (!cex_check_ok(libica_func_list[x])) {
+				V_(printf("Error: mech mode %d has flags unequal to zero!\n",
+					libica_func_list[x].mech_mode_id));
+				failed++;
+			}
+		}
+	}
+
+	//========== Test#2 bad parameter ============
+	rc = ica_get_functionlist(NULL, NULL);
+	if (rc != EINVAL) {
+		V_(printf("Operation failed: Expected: %d Actual: %d\n", EINVAL, rc));
+		failed++;
+	}
+
+	if (failed) {
+		printf("ica_get_functionlist tests for libica-cex failed.\n");
+		return TEST_FAIL;
+	}
+
+	printf("All ica_get_functionlist tests for libica-cex passed.\n");
+	return TEST_SUCC;
+}


### PR DESCRIPTION
This test checks the functionlist of the libica-cex module. All CPACF-related functions and software fallbacks are disabled here, so the mech mode flags must all be zero for these. 