### PR TITLE
TESTCASES: EVP_DigestVerifyInit was not called in eddsa_test

### DIFF
--- a/test/eddsa_test.c
+++ b/test/eddsa_test.c
@@ -324,6 +324,9 @@ static void ed25519_pc(void)
 		EXIT_ERR("libcrypto Ed25519 signature differs.");
 	}
 
+	if (EVP_DigestVerifyInit(ctx2, &pctx, NULL, NULL, pkey) != 1)
+		EXIT_ERR("EVP_DigestVerifyInit failed.");
+
 	if (EVP_DigestVerify(ctx2, ica_sig, sizeof(ica_sig), msg, msglen) != 1)
 		EXIT_ERR("EVP_DigestVerify failed.");
 
@@ -407,6 +410,9 @@ static void ed448_pc(void)
 		dump_array(ossl_sig, sizeof(ossl_sig));
 		EXIT_ERR("libcrypto Ed448 signature differs.");
 	}
+
+	if (EVP_DigestVerifyInit(ctx2, &pctx, NULL, NULL, pkey) != 1)
+		EXIT_ERR("EVP_DigestVerifyInit failed.");
 
 	if (EVP_DigestVerify(ctx2, ica_sig, sizeof(ica_sig), msg, msglen) != 1)
 		EXIT_ERR("EVP_DigestVerify failed.");


### PR DESCRIPTION
EVP_DigestVerify was called without a EVP_DigestVerifyInit.
This bug shows up when using openssl 3.0.

This fix solves issue https://github.com/opencryptoki/libica/issues/61
