### PR TITLE
libica: fix wrong padding in rsa_crt_check function

### DIFF
--- a/src/ica_api.c
+++ b/src/ica_api.c
@@ -1224,8 +1224,11 @@ unsigned int ica_rsa_crt_key_check(ica_rsa_key_crt_t *rsa_key)
 		/* qInv = (1/q) mod p */
 		BN_mod_inverse(bn_invq, bn_q, bn_p, ctx);
 		memset(tmp_buf, 0, rsa_key->key_length/2);
-		BN_bn2bin(bn_invq, tmp_buf);
-
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
+		BN_bn2bin(bn_invq, tmp_buf + rsa_key->key_length/2 - BN_num_bytes(bn_invq));
+#else
+		BN_bn2binpad(bn_invq, tmp_buf, rsa_key->key_length/2);
+#endif
 		memcpy(rsa_key->qInverse + 8, tmp_buf, rsa_key->key_length/2);
 
 		free(tmp_buf);


### PR DESCRIPTION
When the qinv value has a leading 0, the padding
of this value in the ica_rsa_key_crt_t struct was
not currectly done in the ica_rsa_crt_key_check()
function. Fixed and tested, and works fine now.

Please note, for newer Openssl there is a simpler way to have the right padding:

BN_bn2binpad(bn_invq, tmp_buf, rsa_key->key_length/2);h