### PR TITLE
RSA: limit RSA key length to 4096

### DIFF
--- a/include/ica_api.h
+++ b/include/ica_api.h
@@ -1291,6 +1291,7 @@ int ica_ed448_ctx_del(ICA_ED448_CTX **ctx);
  *
  * @return 0 if successful.
  * EINVAL if at least one invalid parameter is given.
+ * EPERM if modulus bit length is greater than 4096 (CEX adapter restriction).
  * EFAULT if OpenSSL key generation should fail.
  */
 ICA_EXPORT
@@ -1319,6 +1320,7 @@ unsigned int ica_rsa_key_generate_mod_expo(ica_adapter_handle_t adapter_handle,
  *
  * @return 0 if successful.
  * EINVAL if at least one invalid parameter is given.
+ * EPERM if modulus bit length is greater than 4096 (CEX adapter restriction).
  * EFAULT if OpenSSL key generation should fail.
  */
 ICA_EXPORT
@@ -1346,6 +1348,7 @@ unsigned int ica_rsa_key_generate_crt(ica_adapter_handle_t adapter_handle,
  *
  * @return 0 if successful.
  * EINVAL if at least one invalid parameter is given.
+ * EPERM if key bit length is greater than 4096 (CEX adapter restriction).
  * ENOMEM if memory allocation fails.
  * EIO if the operation fails. This should never happen.
  */
@@ -1375,6 +1378,7 @@ unsigned int ica_rsa_mod_expo(ica_adapter_handle_t adapter_handle,
  *
  * @return 0 if successful.
  * EINVAL if at least one invalid parameter is given.
+ * EPERM if key bit length is greater than 4096 (CEX adapter restriction).
  * ENOMEM if memory allocation fails.
  * EIO if the operation fails. This should never happen.
  */


### PR DESCRIPTION
CEX adapters support RSA up to 4096 bits. Although RSA key generation in libica is done via openssl, and therefore even greater key lengths would be supported, such keys could not be processed on CEX adapters afterwards. With the removal of sw fallbacks this is now a hard restriction.
The check is not so obvious: while the modulus_bit_length parm specifies the desired key length in bits, the public_key.key_length and private_key.key_length specify bytes.