### PR TITLE
Compute HMAC from installed library

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -17,11 +17,8 @@ coverage: check
 	cd ${top_builddir}/src && gcov .libs/*.gcda
 
 if ICA_FIPS
-install-data-hook:
-	$(INSTALL) -m 0444 ${top_builddir}/src/.libs/.libica.so.$(VERSION).hmac $(DESTDIR)$(libdir)
-	cd $(DESTDIR)$(libdir) && ln -sf .libica.so.$(VERSION).hmac .libica.so.$(MAJOR).hmac
-	$(INSTALL) -m 0444 ${top_builddir}/src/.libs/.libica-cex.so.$(VERSION).hmac $(DESTDIR)$(libdir)
-	cd $(DESTDIR)$(libdir) && ln -sf .libica-cex.so.$(VERSION).hmac .libica-cex.so.$(MAJOR).hmac
+fipsinstall:
+	 $(AM_V_GEN)$(MAKE) -C src fipsinstall
 if ICA_OPENSSL3
 	test -f $(DESTDIR)$(sysconfdir)/libica || $(MKDIR_P) $(DESTDIR)$(sysconfdir)/libica
 	test -f $(DESTDIR)$(sysconfdir)/libica/openssl3-fips.cnf || $(INSTALL) -m 644 ${top_builddir}/src/openssl3-fips.cnf $(DESTDIR)$(sysconfdir)/libica/openssl3-fips.cnf || true
@@ -37,4 +34,6 @@ if ICA_OPENSSL3
 	if [ -d $(sysconfdir)/libica ]; then rm -rf $(sysconfdir)/libica; fi
 endif
 endif
+
+.PHONY: fipsinstall
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -47,6 +47,12 @@ mp.S	: mp.pl
 	./mp.pl mp.S
 
 if ICA_FIPS
+fipsinstall:
+	$(AM_V_GEN) openssl dgst -sha256 -mac hmac -macopt hexkey:00000000 $(DESTDIR)$(libdir)/libica.so.$(VERSION1) | sed -e 's/^.* //' > $(DESTDIR)$(libdir)/.libica.so.$(VERSION1).hmac
+	$(AM_V_GEN) cd $(DESTDIR)$(libdir) && ln -s .libica.so.$(VERSION1).hmac .libica.so.$(MAJOR).hmac
+	$(AM_V_GEN) openssl dgst -sha256 -mac hmac -macopt hexkey:00000000 $(DESTDIR)$(libdir)/libica-cex.so.$(VERSION1) | sed -e 's/^.* //' > $(DESTDIR)$(libdir)/.libica-cex.so.$(VERSION1).hmac
+	$(AM_V_GEN) cd $(DESTDIR)$(libdir) && ln -s .libica-cex.so.$(VERSION1).hmac .libica-cex.so.$(MAJOR).hmac
+
 hmac-file-lnk: hmac-file
 	$(AM_V_GEN) cd ${top_builddir}/src/.libs && ln -sf .libica.so.$(VERSION1).hmac .libica.so.$(MAJOR).hmac
 	$(AM_V_GEN) cd ${top_builddir}/src/.libs && ln -sf .libica-cex.so.$(VERSION1).hmac .libica-cex.so.$(MAJOR).hmac
@@ -110,4 +116,4 @@ internal_tests_ec_internal_test_SOURCES = \
 		    include/rng.h ../test/testcase.h
 endif
 
-.PHONY: hmac-file hmac-file-lnk
+.PHONY: hmac-file hmac-file-lnk fipsinstall


### PR DESCRIPTION
The HMAC hash was computed from the libica in the build tree, but
the runtime check is run against the installed libica and those 2
files may be different. E.g. if the runtime one has debuginfo stripped
(and placed into a separate file), the hashes are different.
This commit introduces a new make target: fipsinstall, which creates
the HMAC files in the install directory.

Signed-off-by: Joerg Schmidbauer <jschmidb@de.ibm.com>