### PR TITLE
OpenSSL 3.0: Cleanup OpenSSL library context during OpenSSL cleanup

### DIFF
--- a/src/init.c
+++ b/src/init.c
@@ -65,6 +65,18 @@ void end_sigill_section(struct sigaction *oldact, sigset_t *oldset)
 	sigprocmask(SIG_SETMASK, oldset, NULL);
 }
 
+#if OPENSSL_VERSION_PREREQ(3, 0)
+static void openssl_cleanup()
+{
+	if (openssl_provider != NULL)
+		OSSL_PROVIDER_unload(openssl_provider);
+	openssl_provider = NULL;
+	if (openssl_libctx != NULL)
+		OSSL_LIB_CTX_free(openssl_libctx);
+	openssl_libctx = NULL;
+}
+#endif
+
 void __attribute__ ((constructor)) icainit(void)
 {
 	int value;
@@ -106,6 +118,17 @@ void __attribute__ ((constructor)) icainit(void)
 	 * Create a separate library context for libica's use of OpenSSL services
 	 * and explicitly load the 'default' or 'fips' provider for this context.
 	 */
+
+	/*
+	 * Perform libica's context cleanup when OpenSSL cleanup is run.
+	 * Otherwise it might happen that the library destructor is called
+	 * after OpenSSL cleanup has already been performed, and this will
+	 * cause crashes when trying to free our own OpenSSL library context,
+	 * since the contexts have already been freed by OpenSSL cleanup at that
+	 * time.
+	 * */
+	OPENSSL_atexit(openssl_cleanup);
+
 	openssl_libctx = OSSL_LIB_CTX_new();
 	if (openssl_libctx == NULL) {
 		syslog(LOG_ERR, "Libica: failed to create openssl lib context\n");
@@ -148,10 +171,7 @@ void __attribute__ ((destructor)) icaexit(void)
 	stats_munmap(SHM_CLOSE);
 
 #if OPENSSL_VERSION_PREREQ(3, 0)
-	if (openssl_provider != NULL)
-		OSSL_PROVIDER_unload(openssl_provider);
-	if (openssl_libctx != NULL)
-		OSSL_LIB_CTX_free(openssl_libctx);
+	openssl_cleanup();
 #endif
 
 }


### PR DESCRIPTION
Usually libica's own library context is freed in the library destructor when the library is unloaded (i.e. during exit handlers).

OpenSSL also performs its own cleanup in exit handlers, and it may happen that OpenSSL cleanup is performed before the library destructors are called. This may cause crashes when libica's library context has already been freed by OpenSSL cleanup, but the library destructor tries to free it a second time. This causes a double free, and very likely a crash.

Register an OpenSSL cleanup handler to clean up the library context before OpenSSL performs its own cleanup.

Similar fix as for Opencryptoki in https://github.com/opencryptoki/opencryptoki/pull/529