### PR TITLE
Fix memory leak at library unload by uninstantiating global prng instance

### DIFF
--- a/src/include/s390_prng.h
+++ b/src/include/s390_prng.h
@@ -16,5 +16,6 @@
 
 int s390_prng_init(void);
 int s390_prng(unsigned char *output_data, unsigned int output_length);
+void s390_prng_fini(void);
 #endif
 

--- a/src/init.c
+++ b/src/init.c
@@ -158,5 +158,7 @@ void __attribute__ ((destructor)) icaexit(void)
 {
 	rng_fini();
 
+	s390_prng_fini();
+
 	stats_munmap(SHM_CLOSE);
 }

--- a/src/s390_prng.c
+++ b/src/s390_prng.c
@@ -360,3 +360,9 @@ static int s390_prng_seed(void *srv, unsigned int count)
 	return rc;
 }
 #endif /* ICA_FIPS */
+
+void s390_prng_fini(void)
+{
+	if (ica_drbg_global != NULL)
+		ica_drbg_uninstantiate(&ica_drbg_global);
+}


### PR DESCRIPTION
When built in non-FIPS mode, s390_prng_init() initializes a global PRNG instance in the library constructor, which must also be freed in the library destructor. Otherwise it leaks 64 bytes (direct leak) plus 240 bytes (indirect leak) when unloading the library.