### PR TITLE
ECC: Signature verify may also return 12 / 769 for bad signatures

### DIFF
--- a/src/s390_ecc.c
+++ b/src/s390_ecc.c
@@ -1891,6 +1891,13 @@ unsigned int ecdsa_verify_hw(ica_adapter_handle_t adapter_handle,
 		goto ret;
 	}
 
+	/* Treat return code 12 / 769 also as bad signature as per CCA doc */
+	if (((struct CPRBX*)reply_p)->ccp_rtcode == 12 &&
+		((struct CPRBX*)reply_p)->ccp_rscode == 769) {
+		rc = EFAULT;
+		goto ret;
+	}
+
 	if (((struct CPRBX*)reply_p)->ccp_rtcode != 0 ||
 		((struct CPRBX*)reply_p)->ccp_rscode != 0) {
 		rc = EIO;


### PR DESCRIPTION
According to the description of CCA verb "Digital Signature Verify" (CSNDDSV) in "Secure Key Solution with the Common Cryptographic Architecture Application Programmer's Guide Version 7.1" the signature verify request may also return 12 / 769 for bad signatures, in addition to 4 / 429. Treat both return codes as bad signature indication.
