### PR TITLE
v5: reduce the number of open file descriptors

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -4,6 +4,11 @@ SUBDIRS = doc include src test
 
 dist_doc_DATA = AUTHORS ChangeLog INSTALL LICENSE README.md
 EXTRA_DIST = libica.map libica.spec
+DISTCLEANFILES = *~
+MAINTAINERCLEANFILES = test-driver \
+	Makefile.in aclocal.m4 compile configure config.guess \
+	config.sub depcomp install-sh ltmain.sh m4/* missing \
+	depcomp ylwrap
 MAJOR := `echo $(VERSION) | cut -d. -f1`
 
 coverage: check

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -1,1 +1,2 @@
 dist_man1_MANS = icastats.1 icainfo.1 icainfo-cex.1
+MAINTAINERCLEANFILES = Makefile.in

--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -1,1 +1,2 @@
 include_HEADERS = ica_api.h
+MAINTAINERCLEANFILES = Makefile.in

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -117,3 +117,6 @@ internal_tests_ec_internal_test_SOURCES = \
 endif
 
 .PHONY: hmac-file hmac-file-lnk fipsinstall
+
+CLEANFILES = mp.S
+MAINTAINERCLEANFILES = Makefile.in

--- a/src/fips.c
+++ b/src/fips.c
@@ -1085,7 +1085,7 @@ _err_:
 }
 
 static int
-des3_cbc_cs_kat(void){
+des3_cbc_cs_kat(void) {
 	const struct des3_cbc_cs_tv *tv;
 	size_t i;
 	unsigned char iv[DES3_BLKSIZE], *out;

--- a/src/ica_api.c
+++ b/src/ica_api.c
@@ -2311,7 +2311,9 @@ int ica_x25519_key_gen(ICA_X25519_CTX *ctx)
 	memset(ctx, 0, sizeof(*ctx));
 	ctx->pub_init = 0;
 
-	rng_gen(ctx->priv, 32);
+	if (rng_gen(ctx->priv, 32))
+		return -1;
+
 	ctx->priv_init = 1;
 	return 0;
 #endif /* NO_CPACF */
@@ -2329,7 +2331,9 @@ int ica_x448_key_gen(ICA_X448_CTX *ctx)
 	memset(ctx, 0, sizeof(*ctx));
 	ctx->pub_init = 0;
 
-	rng_gen(ctx->priv, 56);
+	if(rng_gen(ctx->priv, 56))
+		return -1;
+
 	ctx->priv_init = 1;
 	return 0;
 #endif /* NO_CPACF */
@@ -2347,7 +2351,9 @@ int ica_ed25519_key_gen(ICA_ED25519_CTX *ctx)
 	memset(ctx, 0, sizeof(*ctx));
 	ctx->pub_init = 0;
 
-	rng_gen(ctx->sign_param.priv, sizeof(ctx->sign_param.priv));
+	if (rng_gen(ctx->sign_param.priv, sizeof(ctx->sign_param.priv)))
+		return -1;
+
 	ctx->priv_init = 1;
 	return 0;
 #endif /* NO_CPACF */
@@ -2365,8 +2371,10 @@ int ica_ed448_key_gen(ICA_ED448_CTX *ctx)
 	memset(ctx, 0, sizeof(*ctx));
 	ctx->pub_init = 0;
 
-	rng_gen(ctx->sign_param.priv + 64 - 57,
-		sizeof(ctx->sign_param.priv) - (64 - 57));
+	if (rng_gen(ctx->sign_param.priv + 64 - 57,
+		    sizeof(ctx->sign_param.priv) - (64 - 57)))
+		return -1;
+
 	ctx->priv_init = 1;
 	return 0;
 #endif /* NO_CPACF */

--- a/src/icastats.c
+++ b/src/icastats.c
@@ -291,7 +291,7 @@ int main(int argc, char *argv[])
 		return EXIT_SUCCESS;
 	} else if(delete){
 		stats_mmap(user);
-		stats_munmap(SHM_DESTROY);
+		stats_munmap(user, SHM_DESTROY);
 		return EXIT_SUCCESS;
 	}
 	if(all){

--- a/src/icastats.c
+++ b/src/icastats.c
@@ -88,7 +88,7 @@ void print_stats(stats_entry_t *stats, int key_sizes)
 		if (!key_sizes && strncmp(STATS_DESC[i], "- ", 2) == 0)
 			continue;
 
-		if(i <= ICA_STATS_RSA_CRT_4096) {
+		if (i <= ICA_STATS_RSA_CRT_4096) {
 			printf(" %14s |        %*lu          |         %*lu\n",
 			       STATS_DESC[i],
 			       CELL_SIZE,
@@ -106,8 +106,7 @@ void print_stats(stats_entry_t *stats, int key_sizes)
 			       stats[i].enc.sw,
 			       CELL_SIZE,
 			       stats[i].dec.sw);
-
-	       }
+		}
 	}
 }
 
@@ -222,7 +221,7 @@ int main(int argc, char *argv[])
 			reset = 1;
 			break;
 		case 'R':
-			if(geteuid() != 0){
+			if (geteuid() != 0) {
 				fprintf(stderr,"You have no rights to reset all shared memory"
 					" segments!\n");
 				return EXIT_FAILURE;
@@ -233,16 +232,15 @@ int main(int argc, char *argv[])
 			delete = 1;
 			break;
 		case 'D':
-			if(geteuid() != 0){
+			if (geteuid() != 0) {
 				fprintf(stderr,"You have no rights to delete all shared memory"
 					" segments!\n");
 				return EXIT_FAILURE;
 			}
-
 			delete = 2;
 			break;
 		case 'U':
-			if((pswd = getpwnam(optarg)) == NULL){
+			if ((pswd = getpwnam(optarg)) == NULL) {
 				fprintf(stderr, "The username %s is not known"
 					" on this system.\n", optarg );
 				return EXIT_FAILURE;
@@ -283,24 +281,24 @@ int main(int argc, char *argv[])
 		return EXIT_FAILURE;
 	}
 
-	if(delete == 2){
-		if(delete_all() == -1){
+	if (delete == 2) {
+		if (delete_all() == -1) {
 			perror("deleteall: ");
 			return EXIT_FAILURE;
 		}
 		return EXIT_SUCCESS;
-	} else if(delete){
+	} else if (delete) {
 		stats_mmap(user);
 		stats_munmap(user, SHM_DESTROY);
 		return EXIT_SUCCESS;
 	}
-	if(all){
+	if (all) {
 		char *usr;
 		stats_entry_t *entries;
 		if (json)
 			print_json_header();
-		while((usr = get_next_usr()) != NULL){
-			if((entries = malloc(sizeof(stats_entry_t)*ICA_NUM_STATS)) == NULL){
+		while ((usr = get_next_usr()) != NULL){
+			if ((entries = malloc(sizeof(stats_entry_t)*ICA_NUM_STATS)) == NULL) {
 				perror("malloc: ");
 				return EXIT_FAILURE;
 			}
@@ -320,12 +318,12 @@ int main(int argc, char *argv[])
 
 	if (sum){
 		stats_entry_t *entries;
-		if((entries = malloc(sizeof(stats_entry_t)*ICA_NUM_STATS)) == NULL){
+		if ((entries = malloc(sizeof(stats_entry_t)*ICA_NUM_STATS)) == NULL) {
 			perror("malloc: ");
 			return EXIT_FAILURE;
 		}
 
-		if(!get_stats_sum(entries)){
+		if (!get_stats_sum(entries)) {
 			perror("get_stats_sum: ");
 			return EXIT_FAILURE;
 		}
@@ -339,12 +337,12 @@ int main(int argc, char *argv[])
 		return EXIT_SUCCESS;
 	}
 
-	if(reset == 2){
-		while(get_next_usr() != NULL)
+	if (reset == 2) {
+		while (get_next_usr() != NULL)
 			stats_reset();
 		return EXIT_SUCCESS;
-
 	}
+
 	/* Need to open shm before it can be reseted */
 	if (stats_mmap(user)) {
 		fprintf(stderr, "Could not map shared memory region to local "
@@ -354,9 +352,9 @@ int main(int argc, char *argv[])
 
 	if (reset) {
 		stats_reset();
-	} else{
+	} else {
 		stats_entry_t *stats;
-		if((stats = malloc(sizeof(stats_entry_t)*ICA_NUM_STATS)) == NULL){
+		if ((stats = malloc(sizeof(stats_entry_t)*ICA_NUM_STATS)) == NULL) {
 			perror("malloc: ");
 			return EXIT_FAILURE;
 		}

--- a/src/icastats_shared.c
+++ b/src/icastats_shared.c
@@ -75,7 +75,7 @@ int stats_mmap(int user)
 					 PROT_WRITE, MAP_SHARED,
 					 stats_shm_handle, 0);
 
-	if (stats == MAP_FAILED){
+	if (stats == MAP_FAILED) {
 		stats = NULL;
 		goto end;
 	}
@@ -105,7 +105,7 @@ void stats_munmap(int user, int unlink)
 	munmap(stats, STATS_SHM_SIZE);
 	stats = NULL;
 
-	if(unlink == SHM_DESTROY) {
+	if (unlink == SHM_DESTROY) {
 		char shm_id[NAME_LENGHT];
 
 		sprintf(shm_id, "icastats_%d",
@@ -158,7 +158,7 @@ static uint64_t calc_summary(stats_fields_t start, unsigned int num,
 void get_stats_data(stats_entry_t *entries)
 {
 	unsigned int i;
-	for(i = 0; i < ICA_NUM_STATS; i++) {
+	for (i = 0; i < ICA_NUM_STATS; i++) {
 		switch (i) {
 		case ICA_STATS_AES_ECB:
 		case ICA_STATS_AES_CBC:
@@ -243,32 +243,32 @@ int get_stats_sum(stats_entry_t *sum)
 	DIR *shmDir;
 
 	memset(sum, 0, sizeof(stats_entry_t)*ICA_NUM_STATS);
-	if((shmDir = opendir("/dev/shm")) == NULL)
+	if ((shmDir = opendir("/dev/shm")) == NULL)
 		return 0;
 
-	while((direntp = readdir(shmDir)) != NULL){
-		if(strstr(direntp->d_name, "icastats_") != NULL){
+	while ((direntp = readdir(shmDir)) != NULL) {
+		if (strstr(direntp->d_name, "icastats_") != NULL) {
 			int fd;
 			stats_entry_t *tmp;
 
-			if((getpwuid(atoi(&direntp->d_name[9]))) == NULL){
+			if ((getpwuid(atoi(&direntp->d_name[9]))) == NULL) {
 				closedir(shmDir);
 				return 0;
 			}
 
-			if ((fd = shm_open(direntp->d_name, O_RDONLY, 0)) == -1){
+			if ((fd = shm_open(direntp->d_name, O_RDONLY, 0)) == -1) {
 				closedir(shmDir);
 				return 0;
 			}
 			if ((tmp = (stats_entry_t *)mmap(NULL, STATS_SHM_SIZE,
 						    PROT_READ, MAP_SHARED,
-						    fd, 0)) == MAP_FAILED){
+						    fd, 0)) == MAP_FAILED) {
 				closedir(shmDir);
 				close(fd);
 				return 0;
 			}
 
-			for(i = 0; i<ICA_NUM_STATS; ++i){
+			for (i = 0; i<ICA_NUM_STATS; ++i) {
 				sum[i].enc.hw += tmp[i].enc.hw;
 				sum[i].enc.sw += tmp[i].enc.sw;
 				sum[i].dec.hw += tmp[i].dec.hw;
@@ -302,21 +302,21 @@ char *get_next_usr()
 	/* Closes shm and set stats NULL */
 	stats_munmap(-1, SHM_CLOSE);
 
-	if(shmDir == NULL){
-		if((shmDir = opendir("/dev/shm")) == NULL)
+	if (shmDir == NULL) {
+		if ((shmDir = opendir("/dev/shm")) == NULL)
 			return NULL;
 	}
-	while((direntp = readdir(shmDir)) != NULL){
-		if(strstr(direntp->d_name, "icastats_") != NULL){
+	while ((direntp = readdir(shmDir)) != NULL) {
+		if (strstr(direntp->d_name, "icastats_") != NULL) {
 			int uid = atoi(&direntp->d_name[9]);
 			struct passwd *pwd;
-			if((pwd = getpwuid(uid)) == NULL)
+			if ((pwd = getpwuid(uid)) == NULL)
 				return NULL;
-			if(stats_mmap(uid) == -1)
+			if (stats_mmap(uid) == -1)
 				return NULL;
 
 			return pwd->pw_name;
-		} else{
+		} else {
 			continue;
 		}
 	}
@@ -342,7 +342,7 @@ void stats_increment(stats_fields_t field, int hardware, int direction)
 	if (stats == NULL)
 		return;
 
-	if(direction == ENCRYPT)
+	if (direction == ENCRYPT)
 		if (hardware == ALGO_HW)
 			__sync_add_and_fetch(&stats[field].enc.hw, 1);
 		else
@@ -378,12 +378,13 @@ int delete_all()
 	stats_munmap(-1, SHM_DESTROY);
 	struct dirent *direntp;
 	DIR *shmDir;
-	if((shmDir = opendir("/dev/shm")) == NULL)
+
+	if ((shmDir = opendir("/dev/shm")) == NULL)
 		return 0;
 
-	while((direntp = readdir(shmDir)) != NULL){
-		if(strstr(direntp->d_name, "icastats_") != NULL){
-			if(shm_unlink(direntp->d_name) == -1)
+	while ((direntp = readdir(shmDir)) != NULL) {
+		if (strstr(direntp->d_name, "icastats_") != NULL) {
+			if (shm_unlink(direntp->d_name) == -1)
 				return 0;
 		}
 	}

--- a/src/icastats_shared.c
+++ b/src/icastats_shared.c
@@ -55,19 +55,17 @@ int stats_mmap(int user)
 	sprintf(shm_id, "icastats_%d",
 		user == -1 ? geteuid() : (uid_t)user);
 
-	stats_shm_handle = shm_open(shm_id, O_RDWR,  S_IRUSR | S_IWUSR);
-	if (stats_shm_handle == NOT_INITIALIZED)
-		stats_shm_handle = shm_open(shm_id, O_CREAT | O_RDWR,
-					    S_IRUSR | S_IWUSR);
+	stats_shm_handle = shm_open(shm_id,
+				    O_CREAT | O_RDWR,
+				    S_IRUSR | S_IWUSR);
 
 	if (stats_shm_handle == NOT_INITIALIZED)
 		return -1;
 
-	if (user > 0 && geteuid() == 0) {
-		if (fchown(stats_shm_handle, user, user) == -1) {
-			close(stats_shm_handle);
-			return -1;
-		}
+	if ((user > 0 && geteuid() == 0) &&
+	    (fchown(stats_shm_handle, user, user) == -1)) {
+		close(stats_shm_handle);
+		return -1;
 	}
 
 	if (fstat(stats_shm_handle, &stat_buf)) {

--- a/src/include/icastats.h
+++ b/src/include/icastats.h
@@ -285,7 +285,7 @@ typedef enum stats_fields {
 
 
 int stats_mmap(int user);
-void stats_munmap(int unlink);
+void stats_munmap(int user, int unlink);
 uint64_t stats_query(stats_fields_t field, int hardware, int direction);
 void get_stats_data(stats_entry_t *entries);
 void stats_increment(stats_fields_t field, int hardware, int direction);

--- a/src/include/rng.h
+++ b/src/include/rng.h
@@ -14,7 +14,7 @@
  * directly via the api.
  */
 void rng_init(void);
-void rng_gen(unsigned char *buf, size_t buflen);
+int rng_gen(unsigned char *buf, size_t buflen);
 void rng_fini(void);
 
 #endif

--- a/src/init.c
+++ b/src/init.c
@@ -152,6 +152,8 @@ void __attribute__ ((constructor)) icainit(void)
 #if OPENSSL_VERSION_PREREQ(3, 0)
 	openssl3_initialized = 1;
 #endif
+	/* close the remaining open syslog file descriptor */
+	closelog();
 }
 
 void __attribute__ ((destructor)) icaexit(void)

--- a/src/init.c
+++ b/src/init.c
@@ -87,7 +87,7 @@ void __attribute__ ((constructor)) icainit(void)
 	if (!strcmp(program_invocation_name, "icastats"))
 		return;
 
-	if(stats_mmap(-1) == -1){
+	if (stats_mmap(-1) == -1) {
 		syslog(LOG_INFO,
 		  "Failed to access shared memory segment for libica statistics.");
 	}

--- a/src/init.c
+++ b/src/init.c
@@ -160,5 +160,5 @@ void __attribute__ ((destructor)) icaexit(void)
 
 	s390_prng_fini();
 
-	stats_munmap(SHM_CLOSE);
+	stats_munmap(-1, SHM_CLOSE);
 }

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -90,3 +90,6 @@ rsa_keygen3072_test.sh rsa_keygen_test.sh
 icastats_test.c: icastats_test.c.in
 	@SED@   -e s!\@builddir\@!"@abs_top_builddir@/src/"!g < $< > $@-t
 	mv $@-t $@
+
+CLEANFILES = icastats_test.c
+MAINTAINERCLEANFILES = Makefile.in

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -52,7 +52,8 @@ ecdh2_test.sh \
 ecdsa2_test.sh \
 eddsa_test \
 x_test \
-mp_test
+mp_test \
+adapter_handle_test
 
 if ICA_INTERNAL_TESTS
 TESTS += \
@@ -79,7 +80,7 @@ aes_gcm_test aes_gcm_kma_test cbccs_test ccm_test cmac_test sha_test \
 sha1_test sha256_test sha3_224_test sha3_256_test sha3_384_test \
 sha3_512_test shake_128_test shake_256_test rsa_keygen_test \
 rsa_key_check_test rsa_test ec_keygen_test ecdh_test ecdsa_test mp_test \
-eddsa_test x_test get_functionlist_cex_test
+eddsa_test x_test get_functionlist_cex_test adapter_handle_test
 
 EXTRA_DIST = testdata testcase.h rsa_test.h aes_gcm_test.h ecdsa1_test.sh \
 sha2_test.sh ecdh1_test.sh ecdsa2_test.sh ecdh2_test.sh \

--- a/test/adapter_handle_test.c
+++ b/test/adapter_handle_test.c
@@ -1,0 +1,36 @@
+/* This program is released under the Common Public License V1.0
+ *
+ * You should have received a copy of Common Public License V1.0 along with
+ * with this program.
+ */
+
+/* Copyright IBM Corp. 2022 */
+
+#include <stdio.h>
+#include <errno.h>
+
+#include "ica_api.h"
+#include "testcase.h"
+
+int main(int argc, char **argv)
+{
+	ica_adapter_handle_t adapter_handle;
+	int rc;
+
+	set_verbosity(argc, argv);
+
+	rc = ica_open_adapter(&adapter_handle);
+	if (rc != 0) {
+		V_(perror("ica_open_adapter failed"));
+		return TEST_FAIL;
+	}
+
+	if (adapter_handle > 3) {
+		V_(printf("ica_open_adapter: file descriptor value is greater than 3 (current %d).\n",
+			  adapter_handle));
+		return TEST_FAIL;
+	}
+
+	printf("All adapter handle tests passed.\n");
+	return TEST_SUCC;
+}


### PR DESCRIPTION
This PR contains a set of commits to reduce the number of open file descriptors and a few other cleanups.

The cleanup covers the following:
- Patch 1/7: fix the autotools clean targets. Now all generated files will be removed by these targets
- Patch 2/7: add user support in stats_munmap()
- Patch 3-4/7: increase readability of stats_mmap() and remove redundant code

Openssh has a hard limit of open file descriptors, while initiating/handling a connection. If openssh is using openssl with a configured libica engine, this hard limit to only 6 open file descriptors may hurt. 
Patch 5/7 closes the shm fd right after the mmap(), which is common practice since a very long time. Just for the record: the mapped shm segment can be used, even if the file descriptor has been closed. This change also removes the requirements of a global file descriptor.  
Patch 6/7 closes the syslog related file descriptors. This is a brute-force solution, because it closes the descriptors each time a syslog has been called. But it works and while syslog is only used during initialization, it should not hurt. 
Patch 7/7 move the known HMAC load to a separate function. The added comparison also reduces the attack surface.
