### PR TITLE
compile warning fixes

### DIFF
--- a/src/fips.c
+++ b/src/fips.c
@@ -1100,14 +1100,11 @@ ecdh_kat()
 		tv = &ECDH_KAT_TV[i];
 
 		eckey_A = ica_ec_key_new(tv->nid, &privlen);
-		if (!eckey_A)
+		eckey_B = ica_ec_key_new(tv->nid, &privlen);
+		if (!eckey_A || !eckey_B)
 			goto _err_;
 
 		if (ica_ec_key_init(tv->xa, tv->ya, tv->da, eckey_A))
-			goto _err_;
-
-		eckey_B = ica_ec_key_new(tv->nid, &privlen);
-		if (!eckey_B)
 			goto _err_;
 
 		if (ica_ec_key_init(tv->xb, tv->yb, tv->db, eckey_B))

--- a/src/include/s390_ecc.h
+++ b/src/include/s390_ecc.h
@@ -377,7 +377,7 @@ unsigned int eckeygen_hw(ica_adapter_handle_t adapter_handle, ICA_EC_KEY *key);
 
 unsigned int eckeygen_sw(ICA_EC_KEY *key);
 
-int ec_key_check(ICA_EC_KEY *ica_key);
+int ec_key_check(const ICA_EC_KEY *ica_key);
 
 /**
  * returns 1 if the given data length is valid for Crypto Express, 0 otherwise.

--- a/src/s390_ecc.c
+++ b/src/s390_ecc.c
@@ -2476,7 +2476,7 @@ err:
  *    0       success
  *    EINVAL  key check failed
  */
-int ec_key_check(ICA_EC_KEY *ica_key)
+int ec_key_check(const ICA_EC_KEY *ica_key)
 {
 	EVP_PKEY *privkey = NULL, *pubkey = NULL;
 	BIGNUM *d = NULL, *x = NULL, *y = NULL;


### PR DESCRIPTION
This series contains fixes for some compile warnings:
- use of uninitialized variable
- discard of const qualifier