### PR TITLE
ECC: ec_key_check() uses OpenSSL, thus use own library context

### DIFF
--- a/src/s390_ecc.c
+++ b/src/s390_ecc.c
@@ -2524,9 +2524,11 @@ int ec_key_check(const ICA_EC_KEY *icakey)
 	if (icakey == NULL)
 		return 0;
 
+	BEGIN_OPENSSL_LIBCTX(openssl_libctx, rc);
+
 	pkey = icakey2pkey(icakey, &is_public_key);
 	if (pkey == NULL)
-		return 0;
+		goto done;
 
 	pctx = EVP_PKEY_CTX_new(pkey, NULL);
 	if (pctx == NULL)
@@ -2545,6 +2547,7 @@ int ec_key_check(const ICA_EC_KEY *icakey)
 done:
 	EVP_PKEY_free(pkey);
 	EVP_PKEY_CTX_free(pctx);
+	END_OPENSSL_LIBCTX(rc);
 	return rc;
 }
 


### PR DESCRIPTION
The ec_key_check() routine internally uses OpenSSL calls. In case libica is called from an OpenSSL provider, avoid a recursive loop by using libica's own OpenSSL library context with the default or fips provider loaded.