### PR TITLE
bugfix: provide property flags for MSA8 mechanisms

### DIFF
--- a/src/s390_crypto.c
+++ b/src/s390_crypto.c
@@ -562,6 +562,9 @@ int s390_initialize_functionlist()
 			break;
 		case MSA8:
 			e->flags |= *s390_kma_functions[e->id].enabled ? ICA_FLAG_SHW : 0;
+			e->property |= ICA_PROPERTY_AES_128;
+			e->property |= ICA_PROPERTY_AES_192;
+			e->property |= ICA_PROPERTY_AES_256;
 			break;
 		case MSA9:
 			if (e->mech_mode_id == ED25519_KEYGEN


### PR DESCRIPTION
The AES-GCM mechanisms based on the MSA8 KMA instruction
had no property flags indicating available key lengths.
As all 3 key lengths (128, 192, 256) came with MSA8, no
need to individually check for availability.
