### PR TITLE
build: exclude generated sources for distribution

### DIFF
--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -92,5 +92,6 @@ icastats_test.c: icastats_test.c.in
 	@SED@   -e s!\@builddir\@!"@abs_top_builddir@/src/"!g < $< > $@-t
 	mv $@-t $@
 
+nodist_icastats_test_SOURCES = icastats_test.c
 CLEANFILES = icastats_test.c
 MAINTAINERCLEANFILES = Makefile.in


### PR DESCRIPTION
Exclude the generated source file for icastats_test. This fixes the distcheck and related build targets by enforcing the re-generation of the source file.

Signed-off-by: Holger Dengler <dengler@linux.ibm.com>

More detailed explanation: the generated source-file for the icastats_test executable contains the absolute path to the icastats binary. This should avoid, that the test executable use another icastats version for the test (e.g. the one from a package install). For the distribution make targets (dist, dictcheck, et. al.) it is important, that the generated source file test/icastats_test.c is excluded from the distribution tarball, so that the source generation is triggered correctly for the rebuild, e.g. for `make distcheck`.

Without this commit, a clean `./bootstrap.sh ; ./configure ; make distcheck` will fail, caused by the wrong lookup of the icastats-binary in icastats_test.