### PR TITLE
bugfix: permission denied on shared memory segments

### DIFF
--- a/src/icastats_shared.c
+++ b/src/icastats_shared.c
@@ -54,9 +54,10 @@ int stats_mmap(int user)
 	sprintf(shm_id, "icastats_%d",
 		user == -1 ? geteuid() : (uid_t)user);
 
-	stats_shm_handle = shm_open(shm_id,
-				    O_CREAT | O_RDWR,
-				    S_IRUSR | S_IWUSR);
+	stats_shm_handle = shm_open(shm_id, O_RDWR,  S_IRUSR | S_IWUSR);
+
+	if (stats_shm_handle == -1)
+		stats_shm_handle = shm_open(shm_id, O_CREAT | O_RDWR, S_IRUSR | S_IWUSR);
 
 	if (stats_shm_handle == -1)
 		return rc;


### PR DESCRIPTION
A change to the Linux kernel in 4.19 for added security is changing the behavior when opening shared memory segments. The O_CREAT flag must not be used for existing segments.

Signed-off-by: Joerg Schmidbauer <jschmidb@de.ibm.com>