### PR TITLE
New libica version 4.2.2

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+v4.2.2
+   [UPDATE] syslog msgs only in error cases
+   [UPDATE] don't count statistics in fips power-on self tests
+   [PATCH] various fixes and some new tests
 v4.2.1
    [PATCH] fix regression opening shared memory
 v4.2.0

--- a/configure.ac
+++ b/configure.ac
@@ -1,4 +1,4 @@
-AC_INIT([libica], [4.2.1], [https://github.com/opencryptoki/libica/issues],, [https://github.com/opencryptoki/libica])
+AC_INIT([libica], [4.2.2], [https://github.com/opencryptoki/libica/issues],, [https://github.com/opencryptoki/libica])
 
 # save cmdline flags
 cmdline_CFLAGS="$CFLAGS"

--- a/libica.spec
+++ b/libica.spec
@@ -1,5 +1,5 @@
 Name:          libica
-Version:       4.2.1
+Version:       4.2.2
 Release:       1%{?dist}
 Summary:       Interface library to the ICA device driver
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,4 +1,4 @@
-VERSION = 4:2:1
+VERSION = 4:2:2
 
 AM_CFLAGS = @FLAGS@
 MAJOR := `echo $(VERSION) | cut -d: -f1`


### PR DESCRIPTION
[UPDATE] syslog msgs only in error cases
[UPDATE] don't count statistics in fips power-on self tests 
[PATCH] various fixes and some new tests