### PR TITLE
icastats: Fix summary option to display correct summary information

### DIFF
--- a/src/icastats.c
+++ b/src/icastats.c
@@ -302,7 +302,7 @@ int main(int argc, char *argv[])
 				perror("malloc: ");
 				return EXIT_FAILURE;
 			}
-			get_stats_data(entries);
+			get_stats_data(NULL, entries);
 			if (json) {
 				print_stats_json(entries, usr);
 			} else {
@@ -358,7 +358,7 @@ int main(int argc, char *argv[])
 			perror("malloc: ");
 			return EXIT_FAILURE;
 		}
-		get_stats_data(stats);
+		get_stats_data(NULL, stats);
 		if (json) {
 			pswd = getpwuid(user == -1 ? geteuid() : (uid_t)user);
 			if (pswd == NULL) {

--- a/src/include/icastats.h
+++ b/src/include/icastats.h
@@ -286,8 +286,9 @@ typedef enum stats_fields {
 
 int stats_mmap(int user);
 void stats_munmap(int user, int unlink);
-uint64_t stats_query(stats_fields_t field, int hardware, int direction);
-void get_stats_data(stats_entry_t *entries);
+uint64_t stats_query(stats_entry_t *source, stats_fields_t field,
+		     int hardware, int direction);
+void get_stats_data(stats_entry_t *source, stats_entry_t *entries);
 void stats_increment(stats_fields_t field, int hardware, int direction);
 int get_stats_sum(stats_entry_t *sum);
 char *get_next_usr();


### PR DESCRIPTION
The '--summary' option of icastats did not display correct statistics since the introduction of per key keysize counters with libica version 4.0.0.

To display the correct summary counters, the all-key-size-counter values of an algorithm that supports multiple key sizes must be calculated like it is done in get_stats_data(). Adjust get_stats_data() function and friends so that it now also can be called from get_stats_sum() and can optionally operate on a specified statistics segment (i.e. the one where the summary statistics have been calculated in), not just the global one.