### PR TITLE
Rework gcm parm checking

### DIFF
--- a/src/ica_api.c
+++ b/src/ica_api.c
@@ -258,24 +258,16 @@ static unsigned int check_gcm_parms(unsigned long text_length,
 				    const unsigned char *tag, unsigned int tag_length,
 				    unsigned int iv_length)
 {
-#ifdef __s390x__
 	/*
-	 * The following comparisions are alaways false on s390 targets
-	 * due to limited range of data type.
-	 */
-	if ((text_length > S390_GCM_MAX_TEXT_LENGTH) ||
-	    (aad_length > S390_GCM_MAX_AAD_LENGTH))
-		return EINVAL;
-#else
-	(void)text_length;	/* supporess unused param warning */
-	(void)aad_length;
-#endif
-	/*
-	 * The following check must be done but is commented out because
-	 * comparison is always false due to limited range of data type.
+	 * The following comparisons are always false due to limited
+	 * range of data types.
 	 *
-	 * if (iv_length   > S390_GCM_MAX_IV_LENGTH)
-	 *	return EINVAL;
+	 * if ((text_length > S390_GCM_MAX_TEXT_LENGTH) ||
+	 *     (aad_length > S390_GCM_MAX_AAD_LENGTH))
+	 *     return EINVAL;
+	 *
+	 * if (iv_length > S390_GCM_MAX_IV_LENGTH)
+	 *     return EINVAL;
 	 */
 
 	if (iv_length == 0)

--- a/src/include/s390_aes.h
+++ b/src/include/s390_aes.h
@@ -59,8 +59,8 @@ static inline int s390_aes_gcm_hw(unsigned int function_code,
 		unsigned int cv;
 		ica_aes_vector_t tag;
 		ica_aes_vector_t subkey_h;
-		unsigned long long total_aad_length;
-		unsigned long long total_input_length;
+		unsigned long long total_aad_length; /* bit length */
+		unsigned long long total_input_length; /* bit length */
 		ica_aes_vector_t j0;
 		ica_aes_key_len_256_t key;
 	} parm_block;

--- a/src/include/s390_gcm.h
+++ b/src/include/s390_gcm.h
@@ -16,9 +16,23 @@
 
 #include "s390_ctr.h"
 
-#define S390_GCM_MAX_TEXT_LENGTH (0x0000000fffffffe0ul) /* (2^31)-32 */
-#define S390_GCM_MAX_AAD_LENGTH  (0x2000000000000000ul) /* (2^61)    */
-#define S390_GCM_MAX_IV_LENGTH   (0x2000000000000000ul) /* (2^61)    */
+/*
+ * NIST SP 800-38d: bitlen(P) <= 2^39 - 256;
+ *   => 0 <= bytelen(P) <= 2^36 - 32
+ */
+#define S390_GCM_MAX_TEXT_LENGTH         ((2ULL << 36) - 32)
+
+/*
+ * NIST SP 800-38d: bitlen(A) <= 2^64 - 1
+ *   => 0 <= bytelen(A) <= 2^61 - 1
+ */
+#define S390_GCM_MAX_AAD_LENGTH          ((2ULL << 61) - 1)
+
+/*
+ * NIST SP 800-38d: 1 <= bitlen(iv) <= 2^64 - 1
+ *   => 1 <= bytelen(iv) <= 2^61 - 1
+ */
+#define S390_GCM_MAX_IV_LENGTH           ((2ULL << 61) - 1)
 
 /* the recommended iv length for GCM is 96 bit or 12 byte */
 #define GCM_RECOMMENDED_IV_LENGTH 12

--- a/src/include/s390_gcm.h
+++ b/src/include/s390_gcm.h
@@ -51,8 +51,8 @@ struct kma_ctx_t {
 	uint32_t cv;
 	ica_aes_vector_t tag;
 	ica_aes_vector_t subkey_h;
-	uint64_t total_aad_length;
-	uint64_t total_input_length;
+	uint64_t total_aad_length; /* bit length */
+	uint64_t total_input_length; /* bit length */
 	ica_aes_vector_t j0;
 	ica_aes_key_len_256_t key;
 	// Above this line: KMA parmblock, never change!
@@ -735,8 +735,8 @@ static inline int s390_aes_gcm_kma(const unsigned char *in_data,
 		data_length = 0;
 
 	/* Actual lengths needed by KMA */
-	ctx->total_aad_length += aad_length*8;
-	ctx->total_input_length += data_length*8;
+	ctx->total_aad_length += aad_length * 8;
+	ctx->total_input_length += data_length * 8;
 
 	/* Call KMA */
 	rc = s390_kma(hw_fc, ctx,


### PR DESCRIPTION
This pull request does some rework on gcm parm checking for the old and new gcm API:
Some length constants were wrong, some checks were wrong, some checks were missing, and there were some typos in comments. 
