### PR TITLE
GCM: new API function ica_allow_external_gcm_iv_in_fips_mode

### DIFF
--- a/include/ica_api.h
+++ b/include/ica_api.h
@@ -538,6 +538,17 @@ ICA_EXPORT
 void ica_set_stats_mode(int stats_mode);
 
 /**
+ * Allow or disallow using an external GCM iv when running in fips mode.
+ * When running in fips mode, the GCM iv is created internally via an approved
+ * random source. Applications are not allowed to use an own, external iv. If
+ * this function is called with allow = 1, libica will override this behavior
+ * and allow an external GCM iv in fips mode. In this case the application is
+ * responsible for creating the iv in a compliant way. Default is allow = 0.
+ */
+ICA_EXPORT
+void ica_allow_external_gcm_iv_in_fips_mode(int allow);
+
+/**
  * Opens the specified adapter
  * @param adapter_handle Pointer to the file descriptor for the adapter or
  * to DRIVER_NOT_LOADED if opening the crypto adapter failed.

--- a/libica.map
+++ b/libica.map
@@ -196,3 +196,9 @@ LIBICA_4.1.2 {
 	ica_get_build_version;
     local: *;
 } LIBICA_4.1.1;
+
+LIBICA_4.3.0 {
+    global:
+	ica_allow_external_gcm_iv_in_fips_mode;
+    local: *;
+} LIBICA_4.1.2;

--- a/src/ica_api.c
+++ b/src/ica_api.c
@@ -92,6 +92,14 @@ void ica_set_stats_mode(int stats_mode)
 	ica_stats_enabled = stats_mode ? 1 : 0;
 }
 
+int ica_external_gcm_iv_in_fips_mode_allowed = 0;
+
+void ica_allow_external_gcm_iv_in_fips_mode(int allow)
+{
+	ica_external_gcm_iv_in_fips_mode_allowed = allow ? 1 : 0;
+}
+
+
 #ifndef NO_CPACF
 
 static unsigned int check_des_parms(unsigned int mode,
@@ -3728,7 +3736,8 @@ unsigned int ica_aes_gcm_initialize(const unsigned char *iv,
 				unsigned int direction)
 {
 #ifdef ICA_FIPS
-	if (direction == ENCRYPT && (fips & ICA_FIPS_MODE))
+	if (!ica_external_gcm_iv_in_fips_mode_allowed &&
+		direction == ENCRYPT && (fips & ICA_FIPS_MODE))
 		return EPERM;
 #endif /* ICA_FIPS */
 
@@ -3976,7 +3985,8 @@ int ica_aes_gcm_kma_init(unsigned int direction,
 					kma_ctx* ctx)
 {
 #ifdef ICA_FIPS
-	if (direction == ICA_ENCRYPT && (fips & ICA_FIPS_MODE))
+	if (!ica_external_gcm_iv_in_fips_mode_allowed &&
+		direction == ICA_ENCRYPT && (fips & ICA_FIPS_MODE))
 		return EPERM;
 #endif /* ICA_FIPS */
 


### PR DESCRIPTION
When running in fips mode, the GCM iv is created internally via an approved random source. Applications are not allowed to use an own, external iv. The new API function allows to override this behavior and allow an external GCM iv in fips mode. In this case the application is responsible for creating the iv in a compliant way.