### PR TITLE
Initialize mechanism list before initializing OpenSSL in icainit

### DIFF
--- a/src/include/fips.h
+++ b/src/include/fips.h
@@ -25,6 +25,7 @@ int openssl_in_fips_mode(void);
  * Initialize global fips var to 1 resp. 0 when FIPS_FLAG is 1 resp. 0 (or not
  * present).
  */
+void fips_get_indicator(void);
 void fips_init(void);
 
 /*


### PR DESCRIPTION
In libica's library constructor OpenSSL is initialized since commit 05c4e36b1208193cd11fbc39347835c5a112c71b "Ensure OpenSSL config is loaded before creating libica's own library context". This will also cause OpenSSL to evaluate the OpenSSL config file and load providers configured there.

Even without this commit, it can happen when libica is in FIPS mode, that OpenSSL gets implicitly initialized by OpenSSL usage within the FIPS power on tests, which run as part of the library constructor.

If OpenSSL has been initialized by the application already, then the attempt to initialize OpenSSL again by libica is a no-operation. However, if the libica constructor is the very first to initialize OpenSSL this can cause problems. For applications that link against libica (via -lica), the libica library constructor is run before the applications main function, and thus it will most likely be the very first OpenSSL initialization attempt.

If the IBMCA provider is configured in the OpenSSL config file, then it is loaded and initialized during OpenSSL initialization triggered by the libica constructor. During IBMCA provider initialization, it loads libica and queries libica's mechanism list.

The problem is that this happens while we are still in the middle of the libica library constructor, and haven't fully initialized libica. Especially the mechanism list has not yet been set up, and thus the IBMCA provider will get a mechanism list where all algorithms are marked as being not supported. The IBMCA provider will thus not register any of its algorithms, and thus can not be used subsequentially by the application.

Unfortunately OpenSSL evaluates the config file only once, and also the IBMCA provider queries the libica mechanism list only once, so the situation will not change for the lifetime of the calling application.

To fix this, make sure that the mechanism list is initialized before the libica constructor initializes OpenSSL. That way, the IBMCA provider loaded due to the OpenSL initialization attempt from within the libica library constructor will get a valid mechanism list.

Since some mechanisms are dependent on the FIPS flag of libica, it must evaluate the system's FIPS state before it initializes OpenSSL, but finalize the FIPS setup (loading the FIPS provider, etc) only after OpenSSL has been initialized. For that the fips_init() function has been split into two parts.