### PR TITLE
test: disable CEX usage in OpenSSL for all tests

### DIFF
--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -61,10 +61,14 @@ TESTS += \
 ${top_builddir}/src/internal_tests/ec_internal_test
 endif
 
+# disable OpenSSL CEX usage for all tests
+OPENSSL_s390xcap ?= nocex
+
 TEST_EXTENSIONS = .sh .pl
 TESTS_ENVIRONMENT = export LD_LIBRARY_PATH=${builddir}/../src/.libs/:$$LD_LIBRARY_PATH \
 			   PATH=${builddir}/../src/:$$PATH \
-			   LIBICA_TESTDATA=${srcdir}/testdata/;
+			   LIBICA_TESTDATA=${srcdir}/testdata/ \
+			   OPENSSL_s390xcap=${OPENSSL_s390xcap};
 AM_CFLAGS = @FLAGS@ -DNO_SW_FALLBACKS -I${srcdir}/../include/ -I${srcdir}/../src/include/
 LDADD = @LIBS@ ${top_builddir}/src/.libs/libica.so -lcrypto -lpthread
 


### PR DESCRIPTION
OpenSSL supports CEX exploitation since version v3.2.x. Libica and its testcases use OpenSSL as helper and fallback, so disable the CEX acceleration for all tests.

If the environment variable is already set, use it as is without modifying it. In this case, it is up to the user to choose the right settings.

Fixes: Issue #126
Link: https://github.com/opencryptoki/libica/issues/126