### PR TITLE
Add support for building libica with clang and a few fixes

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -38,7 +38,7 @@ AM_PROG_AS
 LT_INIT
 AM_INIT_AUTOMAKE([-Wall -Wno-portability foreign])
 
-FLAGS="-Wall -Wextra -mzarch"
+FLAGS="-Wall -Wextra -m64"
 
 dnl --- check for perl
 AC_PATH_PROG(PERL, perl)

--- a/src/fips.c
+++ b/src/fips.c
@@ -1262,9 +1262,9 @@ _err_:
 static int
 rsa_kat(void)
 {
-	ica_rsa_key_mod_expo_t pubkey;
-	ica_rsa_key_crt_t privkey;
-	ica_adapter_handle_t ah;
+	ica_rsa_key_mod_expo_t pubkey = { 0 };
+	ica_rsa_key_crt_t privkey = { 0 };
+	ica_adapter_handle_t ah = DRIVER_NOT_LOADED;
 	const struct rsa_tv *tv;
 	size_t i, keylen, crtparamlen;
 	unsigned char *out = NULL;

--- a/src/fips.c
+++ b/src/fips.c
@@ -450,7 +450,7 @@ end:
 static int load_known_hmac(const char *path, unsigned char **hmac, long *hmaclen)
 {
 	int rc = -1;
-	FILE *fp;
+	FILE *fp = NULL;
 	char *known_hmac_str = NULL;
 	char *hmacpath, *p;
 	size_t n;
@@ -460,7 +460,7 @@ static int load_known_hmac(const char *path, unsigned char **hmac, long *hmaclen
 		return rc;
 
 	if ((fp = fopen(hmacpath, "r")) == NULL)
-		return rc;
+		goto end;
 
 	if (getline(&known_hmac_str, &n, fp) <= 0)
 		goto end;
@@ -471,7 +471,8 @@ static int load_known_hmac(const char *path, unsigned char **hmac, long *hmaclen
 	*hmac = OPENSSL_hexstr2buf(known_hmac_str, hmaclen);
 	rc = 0;
 end:
-	fclose(fp);
+	if (fp != NULL)
+		fclose(fp);
 	if (known_hmac_str)
 		OPENSSL_cleanse(known_hmac_str, strlen(known_hmac_str));
 	free(known_hmac_str);

--- a/src/ica_api.c
+++ b/src/ica_api.c
@@ -62,9 +62,7 @@ int ica_fallbacks_enabled = 1;
 int ica_fallbacks_enabled = 0;
 #endif
 
-#if defined(NO_SW_FALLBACKS) || defined(NO_CPACF)
 #define UNUSED(var)			((void)(var))
-#endif
 
 void ica_set_fallback_mode(int fallback_mode)
 {
@@ -266,6 +264,9 @@ static unsigned int check_gcm_parms(unsigned long text_length,
 				    const unsigned char *tag, unsigned int tag_length,
 				    unsigned int iv_length)
 {
+	UNUSED(text_length);
+	UNUSED(aad_length);
+
 	/*
 	 * The following comparisons are always false due to limited
 	 * range of data types.

--- a/src/ica_api.c
+++ b/src/ica_api.c
@@ -1740,6 +1740,7 @@ void ica_ec_key_free(ICA_EC_KEY *key)
 	free(key);
 }
 
+#ifndef NO_CPACF
 static inline int check_fips_ed_x(void)
 {
 #ifdef ICA_FIPS
@@ -1749,6 +1750,7 @@ static inline int check_fips_ed_x(void)
 	return 0;
 #endif
 }
+#endif
 
 
 int ica_x25519_ctx_new(ICA_X25519_CTX **ctx)
@@ -4281,6 +4283,7 @@ unsigned int ica_get_functionlist(libica_func_list_element *pmech_list,
  */
 ica_drbg_mech_t *const ICA_DRBG_SHA512 = &DRBG_SHA512;
 
+#ifndef NO_CPACF
 static inline int ica_drbg_error(int status)
 {
 	switch(status) {
@@ -4308,6 +4311,7 @@ static inline int ica_drbg_error(int status)
 		return -1;	/* unreachable */
 	}
 }
+#endif
 
 int ica_drbg_instantiate(ica_drbg_t **sh,
 			 int sec,

--- a/src/perlasm/s390x.pm
+++ b/src/perlasm/s390x.pm
@@ -113,7 +113,7 @@ sub AUTOLOAD {
 	confess(err("PARSE")) if (grep(!defined($_),@_));
 	my $token;
 	for ($AUTOLOAD) {
-		$token=".$1" if (/^.*::([A-Z]+)_?$/);	# uppercase: directive
+		$token=".\L$1\E" if (/^.*::([A-Z]+)_?$/); # uppercase: directive
 		$token="\t$1" if (/^.*::([a-z]+)_?$/);	# lowercase: mnemonic
 		confess(err("PARSE")) if (!defined($token));
 	}

--- a/src/s390_crypto.c
+++ b/src/s390_crypto.c
@@ -149,9 +149,7 @@ static int read_cpuinfo(void)
 	FILE *handle = fopen("/proc/cpuinfo", "r");
 	if (handle) {
 		char buffer[80];
-		int i = 0;
 		while(fgets(buffer, sizeof(buffer), handle)) {
-			i++;
 			if(strstr(buffer,"features") && strstr(buffer,"msa")) {
 				msa = 1;
 				break;

--- a/src/s390_ecc.c
+++ b/src/s390_ecc.c
@@ -1303,21 +1303,25 @@ static unsigned int provide_pubkey(const ICA_EC_KEY *privkey, unsigned char *X, 
 #else
 	eckey = make_pkey(privkey->nid, privkey->D, privlen);
 	if (eckey == NULL) {
+		rc = EFAULT;
 		goto end;
 	}
 
 	if (!EVP_PKEY_get_octet_string_param(eckey, OSSL_PKEY_PARAM_ENCODED_PUBLIC_KEY,
 									NULL, 0, &ecpoint_len)) {
+		rc = EFAULT;
 		goto end;
 	}
 
 	ecpoint = OPENSSL_zalloc(ecpoint_len);
 	if (ecpoint == NULL) {
+		rc = EFAULT;
 		goto end;
 	}
 
 	if (!EVP_PKEY_get_octet_string_param(eckey, OSSL_PKEY_PARAM_ENCODED_PUBLIC_KEY,
 									ecpoint, ecpoint_len, &ecpoint_len)) {
+		rc = EFAULT;
 		goto end;
 	}
 


### PR DESCRIPTION
Configure it via `./configure CC=clang ....` to use clang instead of gcc. 