### PR TITLE
Fips update

### DIFF
--- a/include/ica_api.h
+++ b/include/ica_api.h
@@ -3303,6 +3303,15 @@ unsigned int ica_aes_ccm(unsigned char *payload, unsigned long payload_length,
  * EIO if the operation fails.
  * EFAULT if direction is 0 and the verification of the message authentication
  * code fails.
+ *
+ * Notes on fips mode:
+ *
+ * 1. When running in fips mode and the application uses an external gcm iv by
+ *    allowing this via API function ica_allow_external_gcm_iv_in_fips_mode,
+ *    the gcm init functions are performed normally, but indicate that they are
+ *    used non-approved by setting errno to EPERM.
+ * 2. API function ica_aes_gcm, which does not need/use an init function, is
+ *    blocked unconditionally in fips mode already. So no errno setting here.
  */
 ICA_EXPORT
 unsigned int ica_aes_gcm(unsigned char *plaintext, unsigned long plaintext_length,

--- a/src/fips.c
+++ b/src/fips.c
@@ -998,7 +998,7 @@ aes_gcm_kat(void) {
 		memset(tag, 0, AES_BLKSIZE);
 		memset(out, 0, tv->len);
 		memset(icb, 0, sizeof(icb));
-		memset(icb, 0, sizeof(ucb));
+		memset(ucb, 0, sizeof(ucb));
 		memset(subkey, 0, sizeof(subkey));
 		if ((tv->rv == 0) && (ica_aes_gcm_initialize_internal(tv->iv, tv->ivlen,
 		    tv->key, tv->keylen, icb, ucb, subkey, ICA_ENCRYPT)

--- a/src/fips.c
+++ b/src/fips.c
@@ -1000,6 +1000,7 @@ aes_gcm_kat(void) {
 		memset(icb, 0, sizeof(icb));
 		memset(ucb, 0, sizeof(ucb));
 		memset(subkey, 0, sizeof(subkey));
+		ica_allow_external_gcm_iv_in_fips_mode(1);
 		if ((tv->rv == 0) && (ica_aes_gcm_initialize_internal(tv->iv, tv->ivlen,
 		    tv->key, tv->keylen, icb, ucb, subkey, ICA_ENCRYPT)
 		    || ica_aes_gcm_intermediate(tv->plaintext,
@@ -1013,6 +1014,7 @@ aes_gcm_kat(void) {
 		    ICA_ENCRYPT) || memcmp(tv->ciphertext, out, tv->len)
 		    || memcmp(tv->tag, tag, tv->taglen)))
 			goto _err_;
+		ica_allow_external_gcm_iv_in_fips_mode(0);
 
 		free(tag);
 		free(out);
@@ -1020,6 +1022,7 @@ aes_gcm_kat(void) {
 	return 0;
 
 _err_:
+	ica_allow_external_gcm_iv_in_fips_mode(0);
 	free(tag);
 	free(out);
 #ifndef NO_CPACF

--- a/src/fips.c
+++ b/src/fips.c
@@ -1242,9 +1242,6 @@ ecdsa_kat(void)
 								sigbuf, tv->siglen, tv->k);
 		if (rc)
 			goto _err_;
-		rc = ica_ecdsa_verify(0, eckey, tv->hash, tv->hashlen, sigbuf, tv->siglen);
-		if (rc)
-			goto _err_;
 		if (memcmp(sigbuf, tv->sig, tv->siglen) != 0) {
 			goto _err_;
 		}

--- a/src/fips.c
+++ b/src/fips.c
@@ -1358,4 +1358,56 @@ _err_:
 	syslog(LOG_ERR, "Libica RSA test failed.");
 	return 1;
 }
+
+/*
+ * List of non-fips-approved algorithms
+ */
+const int FIPS_BLACKLIST[] = {DES_ECB, DES_CBC, DES_CBC_CS, DES_OFB,
+	DES_CFB, DES_CTR, DES_CTRLST, DES_CBC_MAC, DES_CMAC, P_RNG, DES3_ECB,
+	DES3_CBC, DES3_CBC_CS, DES3_OFB, DES3_CFB, DES3_CTR, DES3_CTRLST,
+	DES3_CBC_MAC, DES3_CMAC, ED25519_KEYGEN, ED25519_SIGN, ED25519_VERIFY,
+	ED448_KEYGEN, ED448_SIGN, ED448_VERIFY, X25519_KEYGEN, X25519_DERIVE,
+	X448_KEYGEN, X448_DERIVE, RSA_ME, RSA_CRT, SHA512_DRNG };
+const size_t FIPS_BLACKLIST_LEN
+	= sizeof(FIPS_BLACKLIST) / sizeof(FIPS_BLACKLIST[0]);
+
+/*
+ * FIPS service indicator: List of tolerated but non-approved algorithms.
+ */
+const int FIPS_OVERRIDE_LIST[] = { RSA_ME, RSA_CRT, SHA512_DRNG };
+const size_t FIPS_OVERRIDE_LIST_LEN
+	= sizeof(FIPS_OVERRIDE_LIST) / sizeof(FIPS_OVERRIDE_LIST[0]);
+
+/*
+ * Returns 1 if the algorithm identified by @id is FIPS approved.
+ * Returns 0 otherwise.
+ */
+int fips_approved(int id)
+{
+	size_t i;
+
+	for (i = 0; i < FIPS_BLACKLIST_LEN; i++) {
+		if (id == FIPS_BLACKLIST[i])
+			return 0;
+	}
+
+	return 1;
+}
+
+/*
+ * Returns 1 if the algorithm identified by @id is FIPS tolerated, i.e. it is
+ * available via the API in fips mode, but considered non-approved.
+ * Returns 0 otherwise.
+ */
+int fips_override(int id)
+{
+	size_t i;
+
+	for (i = 0; i < FIPS_OVERRIDE_LIST_LEN; i++) {
+		if (id == FIPS_OVERRIDE_LIST[i])
+			return 1;
+	}
+
+	return 0;
+}
 #endif /* FIPS_H */

--- a/src/fips.c
+++ b/src/fips.c
@@ -1362,19 +1362,19 @@ _err_:
 /*
  * List of non-fips-approved algorithms
  */
-const int FIPS_BLACKLIST[] = {DES_ECB, DES_CBC, DES_CBC_CS, DES_OFB,
+int FIPS_BLACKLIST[] = {DES_ECB, DES_CBC, DES_CBC_CS, DES_OFB,
 	DES_CFB, DES_CTR, DES_CTRLST, DES_CBC_MAC, DES_CMAC, P_RNG, DES3_ECB,
 	DES3_CBC, DES3_CBC_CS, DES3_OFB, DES3_CFB, DES3_CTR, DES3_CTRLST,
 	DES3_CBC_MAC, DES3_CMAC, ED25519_KEYGEN, ED25519_SIGN, ED25519_VERIFY,
 	ED448_KEYGEN, ED448_SIGN, ED448_VERIFY, X25519_KEYGEN, X25519_DERIVE,
-	X448_KEYGEN, X448_DERIVE, RSA_ME, RSA_CRT, SHA512_DRNG };
+	X448_KEYGEN, X448_DERIVE, RSA_ME, RSA_CRT, SHA512_DRNG, -1, -1 };
 const size_t FIPS_BLACKLIST_LEN
 	= sizeof(FIPS_BLACKLIST) / sizeof(FIPS_BLACKLIST[0]);
 
 /*
  * FIPS service indicator: List of tolerated but non-approved algorithms.
  */
-const int FIPS_OVERRIDE_LIST[] = { RSA_ME, RSA_CRT, SHA512_DRNG };
+int FIPS_OVERRIDE_LIST[] = { RSA_ME, RSA_CRT, SHA512_DRNG, -1, -1 };
 const size_t FIPS_OVERRIDE_LIST_LEN
 	= sizeof(FIPS_OVERRIDE_LIST) / sizeof(FIPS_OVERRIDE_LIST[0]);
 
@@ -1409,5 +1409,61 @@ int fips_override(int id)
 	}
 
 	return 0;
+}
+
+/*
+ * Following routines add an algo id to a fips list by replacing a
+ * placeholder indicated by -1 by the given id.
+ */
+void add_to_fips_black_list(int id)
+{
+	size_t i;
+
+	for (i = 0; i < FIPS_BLACKLIST_LEN; i++) {
+		if (FIPS_BLACKLIST[i] == -1) {
+			FIPS_BLACKLIST[i] = id;
+			return;
+		}
+	}
+}
+
+void add_to_fips_override_list(int id)
+{
+	size_t i;
+
+	for (i = 0; i < FIPS_OVERRIDE_LIST_LEN; i++) {
+		if (FIPS_OVERRIDE_LIST[i] == -1) {
+			FIPS_OVERRIDE_LIST[i] = id;
+			return;
+		}
+	}
+}
+
+/*
+ * Following routines remove an algo id from a fips list by replacing the
+ * algo id by the placeholder indicated by -1.
+ */
+void remove_from_fips_black_list(int id)
+{
+	size_t i;
+
+	for (i = 0; i < FIPS_BLACKLIST_LEN; i++) {
+		if (FIPS_BLACKLIST[i] == id) {
+			FIPS_BLACKLIST[i] = -1;
+			return;
+		}
+	}
+}
+
+void remove_from_fips_override_list(int id)
+{
+	size_t i;
+
+	for (i = 0; i < FIPS_OVERRIDE_LIST_LEN; i++) {
+		if (FIPS_OVERRIDE_LIST[i] == id) {
+			FIPS_OVERRIDE_LIST[i] = -1;
+			return;
+		}
+	}
 }
 #endif /* FIPS_H */

--- a/src/ica_api.c
+++ b/src/ica_api.c
@@ -4123,6 +4123,12 @@ int ica_aes_gcm_kma_init_internal(unsigned int direction,
 		return EINVAL;
 	}
 
+	if (ctx->iv_allocated_internally == 1) {
+		OPENSSL_cleanse((void*)ctx->iv, ctx->iv_length);
+		free(ctx->iv);
+		ctx->iv_allocated_internally = 0;
+	}
+
 	if (iv == NULL) {
 		/* If the iv is NULL, create it internally via an approved
 		 * random source. The application can obtain the internal iv

--- a/src/icastats.c
+++ b/src/icastats.c
@@ -371,7 +371,7 @@ int main(int argc, char *argv[])
 		} else {
 			print_stats(stats, key_sizes);
 		}
-
+		free(stats);
 	}
 	return EXIT_SUCCESS;
 }

--- a/src/include/fips.h
+++ b/src/include/fips.h
@@ -70,5 +70,9 @@ unsigned int ica_aes_gcm_initialize_internal(const unsigned char *iv,
  */
 int fips_approved(int id);
 int fips_override(int id);
+void add_to_fips_black_list(int id);
+void add_to_fips_override_list(int id);
+void remove_from_fips_black_list(int id);
+void remove_from_fips_override_list(int id);
 #endif /* FIPS_H */
 #endif /* ICA_FIPS */

--- a/src/include/fips.h
+++ b/src/include/fips.h
@@ -66,56 +66,9 @@ unsigned int ica_aes_gcm_initialize_internal(const unsigned char *iv,
 				unsigned int direction);
 
 /*
- * List of non-fips-approved algorithms
+ * Routines that work on the fips algo lists.
  */
-static const int FIPS_BLACKLIST[] = {DES_ECB, DES_CBC, DES_CBC_CS, DES_OFB,
-    DES_CFB, DES_CTR, DES_CTRLST, DES_CBC_MAC, DES_CMAC, P_RNG, DES3_ECB,
-    DES3_CBC, DES3_CBC_CS, DES3_OFB, DES3_CFB, DES3_CTR, DES3_CTRLST,
-    DES3_CBC_MAC, DES3_CMAC, ED25519_KEYGEN, ED25519_SIGN, ED25519_VERIFY,
-    ED448_KEYGEN, ED448_SIGN, ED448_VERIFY, X25519_KEYGEN, X25519_DERIVE,
-    X448_KEYGEN, X448_DERIVE, RSA_ME, RSA_CRT, SHA512_DRNG };
-static const size_t FIPS_BLACKLIST_LEN
-	= sizeof(FIPS_BLACKLIST) / sizeof(FIPS_BLACKLIST[0]);
-
-/*
- * FIPS service indicator: List of tolerated but non-approved algorithms.
- */
-static const int FIPS_OVERRIDE_LIST[] = { RSA_ME, RSA_CRT, SHA512_DRNG };
-static const size_t FIPS_OVERRIDE_LIST_LEN
-	= sizeof(FIPS_OVERRIDE_LIST) / sizeof(FIPS_OVERRIDE_LIST[0]);
-
-/*
- * Returns 1 if the algorithm identified by @id is FIPS approved.
- * Returns 0 otherwise.
- */
-static inline int
-fips_approved(int id)
-{
-        size_t i;
-
-        for (i = 0; i < FIPS_BLACKLIST_LEN; i++) {
-                if (id == FIPS_BLACKLIST[i])
-                        return 0;
-        }
-
-        return 1;
-}
-
-/*
- * Returns 1 if the algorithm identified by @id is FIPS tolerated, i.e. it is
- * available via the API in fips mode, but considered non-approved.
- * Returns 0 otherwise.
- */
-static inline int fips_override(int id)
-{
-	size_t i;
-
-	for (i = 0; i < FIPS_OVERRIDE_LIST_LEN; i++) {
-		if (id == FIPS_OVERRIDE_LIST[i])
-			return 1;
-	}
-
-	return 0;
-}
+int fips_approved(int id);
+int fips_override(int id);
 #endif /* FIPS_H */
 #endif /* ICA_FIPS */

--- a/src/s390_ecc.c
+++ b/src/s390_ecc.c
@@ -1623,7 +1623,7 @@ struct {				\
 		       sizeof(param.P256.hash) - off);
 
 		off = sizeof(param.P256.pub_x)
-				 - privlen_from_nid(pub->nid);
+				 - privlen_from_nid(NID_X9_62_prime256v1);
 
 		memcpy(param.P256.sig_r + off, sig,
 		       sizeof(param.P256.sig_r) - off);
@@ -1647,7 +1647,7 @@ struct {				\
 		       sizeof(param.P384.hash) - off);
 
 		off = sizeof(param.P384.pub_x)
-				 - privlen_from_nid(pub->nid);
+				 - privlen_from_nid(NID_secp384r1);
 
 		memcpy(param.P384.sig_r + off, sig,
 		       sizeof(param.P384.sig_r) - off);
@@ -1671,7 +1671,7 @@ struct {				\
 		       sizeof(param.P521.hash) - off);
 
 		off = sizeof(param.P521.pub_x)
-				 - privlen_from_nid(pub->nid);
+				 - privlen_from_nid(NID_secp521r1);
 
 		memcpy(param.P521.sig_r + off, sig,
 		       sizeof(param.P521.sig_r) - off);

--- a/src/s390_rsa.c
+++ b/src/s390_rsa.c
@@ -66,7 +66,7 @@ static unsigned int mod_expo_sw(int arg_length, unsigned char *arg, int exp_leng
 RSA* rsa_key_generate(unsigned int modulus_bit_length,
 		      unsigned long *public_exponent)
 {
-	int min_pubexp = 3;
+	unsigned int min_pubexp = 3;
 
 #ifdef ICA_FIPS
 	if ((fips & ICA_FIPS_MODE) && (!openssl_in_fips_mode()))

--- a/test/aes_gcm_kma_test.c
+++ b/test/aes_gcm_kma_test.c
@@ -803,6 +803,12 @@ int test_gcm_with_internal_iv(int iteration)
 		return TEST_FAIL;
 	}
 
+	/* 
+	 * Following API functions would not return the expected rc without
+	 * allowing an external iv.
+	 */
+	ica_allow_external_gcm_iv_in_fips_mode(1);
+
 	/* Update for encrypt */
 	rc = ica_aes_gcm_kma_update(input_data, encrypt, data_length, aad, aad_length, 1, 1, ctx);
 	if (rc == ENODEV) {
@@ -866,6 +872,7 @@ int test_gcm_with_internal_iv(int iteration)
 		rc++;
 	}
 
+	ica_allow_external_gcm_iv_in_fips_mode(0);
 	ica_aes_gcm_kma_ctx_free(ctx);
 
 	if (rc)

--- a/test/cbccs_test.c
+++ b/test/cbccs_test.c
@@ -506,17 +506,15 @@ int main(int argc, char **argv)
 	return TEST_SKIP;
 #else
 	unsigned int variant;
-	int rc, error_count;
+	int rc;
 
 	set_verbosity(argc, argv);
 
 	rc = 0;
-	error_count = 0;
 
 	/* known answer tests for AES128 */
 	rc = test_aes128_new_api();
 	if (rc) {
-		error_count++;
 		printf("test_aes128_new_api for CBC_CS mode with AES-128 "
 		"failed.\n");
 		return TEST_FAIL;
@@ -529,7 +527,6 @@ int main(int argc, char **argv)
 		/* AES 192 & 256 test */
 		rc = test_aes_new_api(variant);
 		if (rc) {
-			error_count++;
 			printf("test_aes_new_api for CBC_CS mode with AES (192|256) "
 			       "failed.\n");
 			return TEST_FAIL;
@@ -538,7 +535,6 @@ int main(int argc, char **argv)
 		/* DES tests */
 		rc = test_des_new_api(variant);
 		if (rc && rc != TEST_SKIP) {
-			error_count++;
 			printf("test_des_new_api for CBC_CS mode with DES "
 			       "failed.\n");
 			return TEST_FAIL;
@@ -547,7 +543,6 @@ int main(int argc, char **argv)
 		/* 3DES tests */
 		rc = test_3des_new_api(variant);
 		if (rc && rc != TEST_SKIP) {
-			error_count++;
 			printf("test_des_new_api for CBC_CS mode with 3DES "
 			       "failed.\n");
 			return TEST_FAIL;

--- a/test/des_cbc_test.c
+++ b/test/des_cbc_test.c
@@ -62,6 +62,11 @@ void get_sizes(unsigned int *data_length, unsigned int *iv_length,
 			*iv_length = sizeof(NIST_IV_CBC_E1);
 			*key_length = sizeof(NIST_KEY_CBC_E1);
 			break;
+		default:
+			*data_length = 0;
+			*iv_length = 0;
+			*key_length = 0;
+			break;
 	}
 
 }

--- a/test/fips_test.c
+++ b/test/fips_test.c
@@ -2,6 +2,7 @@
 #include <openssl/opensslv.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <errno.h>
 
 #include <openssl/opensslconf.h>
 #ifdef OPENSSL_FIPS
@@ -12,6 +13,269 @@
 #include "testcase.h"
 
 #define FIPS_FLAG "/proc/sys/crypto/fips_enabled"
+
+#ifdef ICA_FIPS
+static int test_gcm_iv_usage(void)
+{
+	libica_fips_indicator_element *fips_list = NULL;
+	int rc, i, fips_len, allow, errno_expected, rc_expected;
+	unsigned int approved_expected, override_expected;
+
+	/* Check fips indicator when allowing an external iv in fips mode */
+	for (allow = 0; allow < 2; allow++) {
+
+		approved_expected = allow == 1 ? 0 : 1;
+		override_expected = allow == 1 ? 1 : 0;
+
+		ica_allow_external_gcm_iv_in_fips_mode(allow);
+
+		/* Get fips indicator list */
+		if (ica_get_fips_indicator(NULL, (unsigned int *)&fips_len) != 0) {
+			printf("get_fips_indicator failed\n");
+			rc = EXIT_FAILURE;
+			goto done;
+		}
+
+		fips_list = malloc(sizeof(libica_fips_indicator_element)*fips_len);
+		if (!fips_list) {
+			printf("malloc fips_indicator list failed\n");
+			rc = EXIT_FAILURE;
+			goto done;
+		}
+
+		if (ica_get_fips_indicator(fips_list, (unsigned int *)&fips_len) != 0) {
+			printf("ica_get_fips_indicator failed\n");
+			free(fips_list);
+			rc = EXIT_FAILURE;
+			goto done;
+		}
+
+		for (i = 0; i < fips_len; i++) {
+			if (fips_list[i].mech_mode_id == AES_GCM ||
+				fips_list[i].mech_mode_id == AES_GCM_KMA) {
+				if (fips_list[i].fips_approved != approved_expected ||
+					fips_list[i].fips_override != override_expected) {
+					printf("fips approved/override values not as expected for algo id %d and allow = %d:\n",
+						fips_list[i].mech_mode_id, allow);
+					printf("  fips approved = %d, expected %d\n",
+						fips_list[i].fips_approved, approved_expected);
+					printf("  fips override = %d, expected %d\n",
+						fips_list[i].fips_override, override_expected);
+					rc = EXIT_FAILURE;
+					free(fips_list);
+					goto done;
+				}
+			}
+		}
+
+		free(fips_list);
+	}
+
+	/* Check API behavior when allowing an external iv in fips mode */
+	for (allow = 0; allow < 2; allow++) {
+		unsigned char iv[12], key[16], icb[16], ucb[16], subkey[16];
+		unsigned char aad[16], t[16], msg[64], encmsg[64], running_tag[16];
+
+		ica_allow_external_gcm_iv_in_fips_mode(allow);
+
+		rc_expected = allow == 1 ? 0 : EPERM;
+		errno_expected = allow == 1 ? EPERM : 0;
+
+		/*
+		 * Old API encrypt.
+		 * Note: ica_aes_gcm() is unconditionally blocked in fips mode,
+		 *       so no need for testing this.
+		 */
+		memset(running_tag, 0, sizeof(running_tag));
+
+		rc = ica_aes_gcm_initialize(iv, sizeof(iv), key, sizeof(key),
+				icb, ucb, subkey, ICA_ENCRYPT);
+		if (rc != rc_expected || errno != errno_expected) {
+			printf("rc/errno not as expected from ica_aes_gcm_initialize (encrypt, allow=%d)\n",
+				allow);
+			printf("  rc = %d, expected %d\n", rc, rc_expected);
+			printf("  errno = %d, expected %d\n", errno, errno_expected);
+			rc = EXIT_FAILURE;
+			goto done;
+		}
+
+		rc = ica_aes_gcm_intermediate(msg, sizeof(msg), encmsg, ucb,
+				aad, sizeof(aad), running_tag, 16, key, sizeof(key),
+				subkey, ICA_ENCRYPT);
+		if (rc != rc_expected || errno != errno_expected) {
+			printf("rc/errno not as expected from ica_aes_gcm_intermediate (encrypt, allow=%d)\n",
+				allow);
+			printf("  rc = %d, expected %d\n", rc, rc_expected);
+			printf("  errno = %d, expected %d\n", errno, errno_expected);
+			rc = EXIT_FAILURE;
+			goto done;
+		}
+
+		rc = ica_aes_gcm_last(icb, sizeof(aad), sizeof(msg), running_tag,
+				t, sizeof(t), key, sizeof(key), subkey, ICA_ENCRYPT);
+		if (rc != rc_expected || errno != errno_expected) {
+			printf("rc/errno not as expected from ica_aes_gcm_last (encrypt, allow=%d)\n",
+				allow);
+			printf("  rc = %d, expected %d\n", rc, rc_expected);
+			printf("  errno = %d, expected %d\n", errno, errno_expected);
+			rc = EXIT_FAILURE;
+			goto done;
+		}
+
+		/* Old API decrypt. */
+		rc_expected = 0; /* ext. iv always allowed for decrypt */
+		errno_expected = 0;
+
+		memcpy(t, running_tag, sizeof(t)); /* save running tag for later */
+		memset(running_tag, 0, sizeof(running_tag));
+
+		rc = ica_aes_gcm_initialize(iv, sizeof(iv), key, sizeof(key),
+				icb, ucb, subkey, ICA_DECRYPT);
+		if (rc != rc_expected || errno != errno_expected) {
+			printf("rc/errno not as expected from ica_aes_gcm_initialize (decrypt, allow=%d)\n",
+				allow);
+			printf("  rc = %d, expected %d\n", rc, rc_expected);
+			printf("  errno = %d, expected %d\n", errno, errno_expected);
+			rc = EXIT_FAILURE;
+			goto done;
+		}
+
+		rc = ica_aes_gcm_intermediate(msg, sizeof(msg), encmsg, ucb,
+				aad, sizeof(aad), running_tag, 16, key, sizeof(key),
+				subkey, ICA_DECRYPT);
+		if (rc != rc_expected || errno != errno_expected) {
+			printf("rc/errno not as expected from ica_aes_gcm_intermediate (decrypt, allow=%d)\n",
+				allow);
+			printf("  rc = %d, expected %d\n", rc, rc_expected);
+			printf("  errno = %d, expected %d\n", errno, errno_expected);
+			rc = EXIT_FAILURE;
+			goto done;
+		}
+
+		/*
+		 * Verifying the tag fails with EFAULT if encrypt wasn't allowed
+		 * before, because of allow = 0.
+		 */
+		rc_expected = allow == 0 ? EFAULT : 0;
+
+		rc = ica_aes_gcm_last(icb, sizeof(aad), sizeof(msg), running_tag,
+				t, sizeof(t), key, sizeof(key), subkey, ICA_DECRYPT);
+		if (rc != rc_expected || errno != errno_expected) {
+			printf("rc/errno not as expected from ica_aes_gcm_last (decrypt, allow=%d)\n",
+				allow);
+			printf("  rc = %d, expected %d\n", rc, rc_expected);
+			printf("  errno = %d, expected %d\n", errno, errno_expected);
+			rc = EXIT_FAILURE;
+			goto done;
+		}
+
+		/* New API encrypt. */
+		rc_expected = allow == 1 ? 0 : EPERM;
+		errno_expected = allow == 1 ? EPERM : 0;
+
+		kma_ctx* ctx = ica_aes_gcm_kma_ctx_new();
+		if (!ctx) {
+			printf("Could not allocate KMA context\n");
+			rc = EXIT_FAILURE;
+			goto done;
+		}
+
+		rc = ica_aes_gcm_kma_init(ICA_ENCRYPT, iv, sizeof(iv),
+				key, sizeof(key), ctx);
+		if (rc != rc_expected || errno != errno_expected) {
+			printf("rc/errno not as expected from ica_aes_gcm_kma_init (encrypt, allow=%d)\n",
+				allow);
+			printf("  rc = %d, expected %d\n", rc, rc_expected);
+			printf("  errno = %d, expected %d\n", errno, errno_expected);
+			ica_aes_gcm_kma_ctx_free(ctx);
+			rc = EXIT_FAILURE;
+			goto done;
+		}
+
+		/*
+		 * If the preceding init failed, the ctx is not correctly initialized
+		 * and calling the update, get_tag, etc. functions makes no sense.
+		 * However, applications can do this and the API must return the
+		 * expected rc and errno values.
+		 */
+
+		rc = ica_aes_gcm_kma_update(msg, encmsg, sizeof(msg),
+				aad, sizeof(aad), 1, 1, ctx);
+		if (rc != rc_expected || errno != errno_expected) {
+			printf("rc/errno not as expected from ica_aes_gcm_kma_update (encrypt, allow=%d)\n",
+				allow);
+			printf("  rc = %d, expected %d\n", rc, rc_expected);
+			printf("  errno = %d, expected %d\n", errno, errno_expected);
+			ica_aes_gcm_kma_ctx_free(ctx);
+			rc = EXIT_FAILURE;
+			goto done;
+		}
+
+		rc = ica_aes_gcm_kma_get_tag(t, sizeof(t), ctx);
+		if (rc != rc_expected || errno != errno_expected) {
+			printf("rc/errno not as expected from ica_aes_gcm_kma_get_tag (encrypt, allow=%d)\n",
+				allow);
+			printf("  rc = %d, expected %d\n", rc, rc_expected);
+			printf("  errno = %d, expected %d\n", errno, errno_expected);
+			ica_aes_gcm_kma_ctx_free(ctx);
+			rc = EXIT_FAILURE;
+			goto done;
+		}
+
+		/* New API decrypt. */
+		rc_expected = 0; /* ext. iv always allowed for decrypt */
+		errno_expected = 0;
+
+		rc = ica_aes_gcm_kma_init(ICA_DECRYPT, iv, sizeof(iv),
+				key, sizeof(key), ctx);
+		if (rc != rc_expected || errno != errno_expected) {
+			printf("rc/errno not as expected from ica_aes_gcm_kma_init (decrypt, allow=%d)\n",
+				allow);
+			printf("  rc = %d, expected %d\n", rc, rc_expected);
+			printf("  errno = %d, expected %d\n", errno, errno_expected);
+			ica_aes_gcm_kma_ctx_free(ctx);
+			rc = EXIT_FAILURE;
+			goto done;
+		}
+
+		rc = ica_aes_gcm_kma_update(encmsg, msg, sizeof(msg),
+				aad, sizeof(aad), 1, 1, ctx);
+		if (rc != rc_expected || errno != errno_expected) {
+			printf("rc/errno not as expected from ica_aes_gcm_kma_update (decrypt, allow=%d)\n",
+				allow);
+			printf("  rc = %d, expected %d\n", rc, rc_expected);
+			printf("  errno = %d, expected %d\n", errno, errno_expected);
+			ica_aes_gcm_kma_ctx_free(ctx);
+			rc = EXIT_FAILURE;
+			goto done;
+		}
+
+		/*
+		 * verify_tag fails with EFAULT if encrypt wasn't allowed before,
+		 * because of allow = 0.
+		 */
+		rc_expected = allow == 0 ? EFAULT : 0;
+
+		rc = ica_aes_gcm_kma_verify_tag(t, sizeof(t), ctx);
+		if (rc != rc_expected || errno != errno_expected) {
+			printf("rc/errno not as expected from ica_aes_gcm_kma_verify_tag (decrypt, allow=%d)\n",
+				allow);
+			printf("  rc = %d, expected %d\n", rc, rc_expected);
+			printf("  errno = %d, expected %d\n", errno, errno_expected);
+			ica_aes_gcm_kma_ctx_free(ctx);
+			rc = EXIT_FAILURE;
+			goto done;
+		}
+
+		ica_aes_gcm_kma_ctx_free(ctx);
+	}
+
+	rc = 0;
+
+done:
+	return rc;
+}
+#endif /* ICA_FIPS */
 
 int
 main(void)
@@ -67,6 +331,12 @@ main(void)
 	if (fips & ICA_FIPS_INTEGRITY) {
 		printf("Libica FIPS integrity check failed.\n");
 		rv = EXIT_FAILURE;
+	}
+	if (fips & ICA_FIPS_MODE) {
+		if (test_gcm_iv_usage()) {
+			printf("Libica FIPS gcm iv usage check failed.\n");
+			rv = EXIT_FAILURE;
+		}
 	}
 #endif /* ICA_FIPS */
 


### PR DESCRIPTION
Since the last fips 140-3 update in 2022, a few rules are stricter now:
  1. ECDSA-verify is no longer allowed for CAVP testing
  2. The fips indicator must now be incorporated into the API itself. It's no
     more allowed to just give applications the opportunity to check if an API
     is approved or not.
  3. If an algorithm or API is non-approved, but the library indicates this via
     the fips indicator and allows its usage, the API must distinguish these two
     cases, e.g. via return codes.
