### PR TITLE
Fips addition

### DIFF
--- a/include/ica_api.h
+++ b/include/ica_api.h
@@ -84,6 +84,7 @@ typedef ica_adapter_handle_t ICA_ADAPTER_HANDLE;
 
 #define ICA_PROPERTY_RSA_ALL		0x0000000F /* All RSA key lengths */
 #define ICA_PROPERTY_RSA_FIPS		0x0000000C /* RSA 2k and higher */
+#define ICA_PROPERTY_RSA_NO_SMALL_EXP	0x00010000 /* e >= 65537 */
 #define ICA_PROPERTY_EC_BP			0x00000001 /* Brainpool curves */
 #define ICA_PROPERTY_EC_NIST		0x00000002 /* NIST curves */
 #define ICA_PROPERTY_EC_ED			0x00000004 /* Edwards curves */

--- a/src/s390_crypto.c
+++ b/src/s390_crypto.c
@@ -726,10 +726,12 @@ int s390_get_functionlist(libica_func_list_element *pmech_list,
 		case RSA_KEY_GEN_CRT:
 		case RSA_ME:
 		case RSA_CRT:
-			if (pmech_list[x].flags)
+			if (pmech_list[x].flags) {
 				pmech_list[x].property = ICA_PROPERTY_RSA_FIPS;
-			else
+				pmech_list[x].property |= ICA_PROPERTY_RSA_NO_SMALL_EXP;
+			} else {
 				pmech_list[x].property = 0;
+			}
 			break;
 		default:
 			break;


### PR DESCRIPTION
Introduce a new function list property flag to indicate that no small (< 64k) RSA public exponents are allowed.
Also show the minimum allowed public exponent in the icainfo output