### PR TITLE
CCA adapters are not usable in an Secure Execution guest

### DIFF
--- a/src/s390_crypto.c
+++ b/src/s390_crypto.c
@@ -403,7 +403,11 @@ unsigned int search_for_cards()
 	char buf[250];
 	struct dirent *direntp;
 	char type[6];
-	int rc;
+	int rc, in_se_guest = 0;
+
+	rc = file_fgets("/sys/firmware/uv/prot_virt_guest", buf, sizeof(buf));
+	if (rc == 0 && strcmp(buf, "1") == 0)
+		in_se_guest = 1;
 
 	if ((sysDir = opendir(dev)) == NULL)
 		return 0;
@@ -440,10 +444,10 @@ unsigned int search_for_cards()
 		if (type[4] == 'A')
 			ret |= CARD_AVAILABLE | CEXnA_AVAILABLE;
 
-		if (type[4] == 'C')
+		if (type[4] == 'C' && !in_se_guest)
 			ret |= CARD_AVAILABLE | CEXnC_AVAILABLE;
 
-		if (type[3] >= '4' && type[4] == 'C')
+		if (type[3] >= '4' && type[4] == 'C' && !in_se_guest)
 			ret |= CARD_AVAILABLE | CEX4C_AVAILABLE;
 	}
 

--- a/test/ec_keygen1_test.sh
+++ b/test/ec_keygen1_test.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-if lszcrypt | grep -q -e "CEX.C.*online"; then
+if lszcrypt | grep -q -e "^[0-9a-f][0-9a-f]\.[0-9a-f][0-9a-f][0-9a-f][0-9a-f].*CEX.C.*online"; then
 	ICAPATH=1 ./ec_keygen_test
 else
 	# Show output in log file for debugging

--- a/test/ec_keygen2_test.sh
+++ b/test/ec_keygen2_test.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-if lszcrypt | grep -q -e "CEX.C.*online"; then
+if lszcrypt | grep -q -e "^[0-9a-f][0-9a-f]\.[0-9a-f][0-9a-f][0-9a-f][0-9a-f].*CEX.C.*online"; then
 	ICAPATH=2 ./ec_keygen_test
 else
 	# Show output in log file for debugging

--- a/test/ecdh1_test.sh
+++ b/test/ecdh1_test.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-if lszcrypt | grep -q -e "CEX.C.*online"; then
+if lszcrypt | grep -q -e "^[0-9a-f][0-9a-f]\.[0-9a-f][0-9a-f][0-9a-f][0-9a-f].*CEX.C.*online"; then
 	ICAPATH=1 ./ecdh_test
 else
 	# Show output in log file for debugging

--- a/test/ecdh2_test.sh
+++ b/test/ecdh2_test.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-if lszcrypt | grep -q -e "CEX.C.*online"; then
+if lszcrypt | grep -q -e "^[0-9a-f][0-9a-f]\.[0-9a-f][0-9a-f][0-9a-f][0-9a-f].*CEX.C.*online"; then
 	ICAPATH=2 ./ecdh_test
 else
 	# Show output in log file for debugging

--- a/test/ecdsa1_test.sh
+++ b/test/ecdsa1_test.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-if lszcrypt | grep -q -e "CEX.C.*online"; then
+if lszcrypt | grep -q -e "^[0-9a-f][0-9a-f]\.[0-9a-f][0-9a-f][0-9a-f][0-9a-f].*CEX.C.*online"; then
 	ICAPATH=1 ./ecdsa_test
 else
 	# Show output in log file for debugging

--- a/test/ecdsa2_test.sh
+++ b/test/ecdsa2_test.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-if lszcrypt | grep -q -e "CEX.C.*online"; then
+if lszcrypt | grep -q -e "^[0-9a-f][0-9a-f]\.[0-9a-f][0-9a-f][0-9a-f][0-9a-f].*CEX.C.*online"; then
 	ICAPATH=2 ./ecdsa_test
 else
 	# Show output in log file for debugging


### PR DESCRIPTION
Trying to use CCA adapters in an Secure Execution guest fails, because CCA adapters are not usable there. Nevertheless they show up as online, so special checking needs to be added to detect this situation.

Don't set the 'ecc_via_online_card' flag in such case, so that the EC mechanisms are reported to not be available with dynamic hardware when running in an Secure Execution guest, and attempts to use curves that would require a CCA adapter fail with ENODEV. This can then be handled by the calling applications appropriately.