### PR TITLE
Fix declaration of ica_aes_gcm_kma_ctx_new in ica_api.h header

### DIFF
--- a/include/ica_api.h
+++ b/include/ica_api.h
@@ -3370,7 +3370,7 @@ typedef struct kma_ctx_t kma_ctx;
  * NULL if no memory could be allocated.
  */
 ICA_EXPORT
-kma_ctx* ica_aes_gcm_kma_ctx_new();
+kma_ctx* ica_aes_gcm_kma_ctx_new(void);
 
 /**
  * Initialize the GCM context. This description applies to both,


### PR DESCRIPTION
When building an application that includes ica_api.h with -Wstrict-prototypes, then this shows warnings/errors for the ica_aes_gcm_kma_ctx_new() declaration in ica_api.h.

The declaration in ica_api.h is anyway different that the one used in ica_api.c:

ica_api.h:
```
  ICA_EXPORT
  kma_ctx* ica_aes_gcm_kma_ctx_new();
```

ica_api.c:
`  kma_ctx* ica_aes_gcm_kma_ctx_new(void)`