### PR TITLE
CONFIGURE: Make the OpenSSL FIPS config file name configurable

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -100,6 +100,13 @@ if test "x$enable_fips" = xyes; then
     fi
 fi
 
+dnl --- with-fips-config
+AC_ARG_WITH([fips-config],
+	AS_HELP_STRING([--with-fips-config=FILE],[OpenSSL FIPS config file name. Default is fipsmodule.cnf]),
+	[], [with_fips_config=fipsmodule.cnf])
+FIPSCONFIGFILE="$with_fips_config"
+AC_SUBST(FIPSCONFIGFILE)
+
 dnl --- enable_sanitizer
 AC_ARG_ENABLE(sanitizer,
               [  --enable-sanitizer      turn on sanitizer (may not work on all systems)],

--- a/src/openssl3-fips.cnf.in
+++ b/src/openssl3-fips.cnf.in
@@ -1,6 +1,6 @@
 openssl_conf = openssl_init
 
-.include @FIPSDIR@/fipsmodule.cnf
+.include @FIPSDIR@/@FIPSCONFIGFILE@
 
 [openssl_init]
 providers = provider_sect


### PR DESCRIPTION
The name of the OpenSSL FIPS config file may be different on various distros. It is included in src/openssl3-fips.cnf when used with OpenSSL 3.0 or later.

To use a specific name:
  ./configure --enable-fips --with-fips-config=fips_local.cnf

The default remains fipsmodule.cnf. It is only used when --enable-fips is also specified, and libica is built against OpenSSL 3.0 or later.