### PR TITLE
icastats: Do not overflow statistics counters, saturate at max

### DIFF
--- a/doc/icastats.1
+++ b/doc/icastats.1
@@ -68,6 +68,16 @@ or system shut down. This also means that the statistical data shown with
 icastats is on a per user base and only the root user is able to see and
 maintain the collection of statistic data from libica at system scope.
 .P
+Counter values saturate at their maximum (UINT64_MAX = 18446744073709551615)
+rather than wrapping around. A saturated counter is displayed as
+.B [saturated]
+in the default text output. In JSON output, an additional boolean field with
+the suffix
+.B \-saturated
+set to
+.B true
+is emitted alongside the counter value.
+.P
 Newer operating systems might remove these shared memory segments
 after the user has logged out from the system (systemd cleanup action).
 In this case all collected statistic data are gone.
@@ -112,7 +122,10 @@ show statistic values from the given user (only root user)
 .IP "-k or --key-sizes"
 show libica statistic data per key size
 .IP "-j or --json"
-output the statistics in JSON format
+output the statistics in JSON format.
+Saturated counters are indicated by an extra
+.B \-saturated: true
+field next to the affected counter value.
 .SH FILES
 .nf
 /shm/dev/icastats_<userid>

--- a/src/icastats.c
+++ b/src/icastats.c
@@ -19,6 +19,7 @@
 #include <string.h>
 #include <ctype.h>
 #include <getopt.h>
+#include <limits.h>
 #include <pwd.h>
 #include <libgen.h>
 #include <errno.h>
@@ -77,6 +78,15 @@ const char *const STATS_DESC[ICA_NUM_STATS] = {
 
 
 #define CELL_SIZE 12
+
+static void fmt_counter(char *buf, size_t len, uint64_t val)
+{
+	if (val == UINT64_MAX)
+		snprintf(buf, len, "[saturated]");
+	else
+		snprintf(buf, len, "%lu", val);
+}
+
 void print_stats(stats_entry_t *stats, int key_sizes)
 {
 	printf(" function       |             hardware         |              software\n");
@@ -84,33 +94,47 @@ void print_stats(stats_entry_t *stats, int key_sizes)
 	printf("                |        ENC    CRYPT     DEC  |        ENC     CRYPT    DEC \n");
 	printf("----------------+------------------------------+-----------------------------\n");
 	unsigned int i;
+	char hw_enc[16], hw_dec[16], sw_enc[16], sw_dec[16];
+
 	for (i = 0; i < ICA_NUM_STATS; ++i) {
 		if (!key_sizes && strncmp(STATS_DESC[i], "- ", 2) == 0)
 			continue;
 
+		fmt_counter(hw_enc, sizeof(hw_enc), stats[i].enc.hw);
+		fmt_counter(hw_dec, sizeof(hw_dec), stats[i].dec.hw);
+		fmt_counter(sw_enc, sizeof(sw_enc), stats[i].enc.sw);
+		fmt_counter(sw_dec, sizeof(sw_dec), stats[i].dec.sw);
+
 		if (i <= ICA_STATS_RSA_CRT_4096) {
-			printf(" %14s |        %*lu          |         %*lu\n",
+			printf(" %14s |        %*s          |         %*s\n",
 			       STATS_DESC[i],
-			       CELL_SIZE,
-			       stats[i].enc.hw,
-			       CELL_SIZE,
-			       stats[i].enc.sw);
+			       CELL_SIZE, hw_enc,
+			       CELL_SIZE, sw_enc);
 		} else {
-			printf(" %14s |%*lu     %*lu |%*lu    %*lu\n",
+			printf(" %14s |%*s     %*s |%*s    %*s\n",
 			       STATS_DESC[i],
-			       CELL_SIZE,
-			       stats[i].enc.hw,
-			       CELL_SIZE,
-			       stats[i].dec.hw,
-			       CELL_SIZE,
-			       stats[i].enc.sw,
-			       CELL_SIZE,
-			       stats[i].dec.sw);
+			       CELL_SIZE, hw_enc,
+			       CELL_SIZE, hw_dec,
+			       CELL_SIZE, sw_enc,
+			       CELL_SIZE, sw_dec);
 		}
 	}
 }
 
 static int first_usr;
+
+static void print_json_string(const char *s)
+{
+	for (; *s != '\0'; s++) {
+		unsigned char c = (unsigned char)*s;
+		if (c == '"' || c == '\\')
+			printf("\\%c", c);
+		else if (c < 0x20)
+			printf("\\u%04x", c);
+		else
+			putchar(c);
+	}
+}
 
 void print_json_header()
 {
@@ -131,10 +155,18 @@ void print_json_header()
 	}
 
 	printf("{\n\t\"host\": {\n");
-	printf("\t\t\"nodename\": \"%s\",\n", un.nodename);
-	printf("\t\t\"sysname\": \"%s\",\n", un.sysname);
-	printf("\t\t\"release\": \"%s\",\n", un.release);
-	printf("\t\t\"machine\": \"%s\",\n", un.machine);
+	printf("\t\t\"nodename\": \""); 
+	print_json_string(un.nodename); 
+	printf("\",\n");
+	printf("\t\t\"sysname\": \"");  
+	print_json_string(un.sysname);  
+	printf("\",\n");
+	printf("\t\t\"release\": \"");  
+	print_json_string(un.release);  
+	printf("\",\n");
+	printf("\t\t\"machine\": \"");  
+	print_json_string(un.machine);  
+	printf("\",\n");
 	printf("\t\t\"date\": \"%s\"\n", timestamp);
 	printf("\t},\n\t\"users\": [");
 
@@ -148,7 +180,9 @@ void print_stats_json(stats_entry_t *stats, const char *usr)
 
 	if (!first_usr)
 		printf(",");
-	printf("\n\t\t{\n\t\t\t\"user\": \"%s\",\n", usr);
+	printf("\n\t\t{\n\t\t\t\"user\": \"");
+	print_json_string(usr);
+	printf("\",\n");
 	printf("\t\t\t\"functions\": [");
 
 	for (i = 0; i < ICA_NUM_STATS; ++i) {
@@ -175,17 +209,29 @@ void print_stats_json(stats_entry_t *stats, const char *usr)
 		if (i <= ICA_STATS_RSA_CRT_4096) {
 			printf("\t\t\t\t\t\"hw-crypt\": %lu,\n",
 			       stats[i].enc.hw);
+			if (stats[i].enc.hw == UINT64_MAX)
+				printf("\t\t\t\t\t\"hw-crypt-saturated\": true,\n");
 			printf("\t\t\t\t\t\"sw-crypt\": %lu\n",
 			       stats[i].enc.sw);
+			if (stats[i].enc.sw == UINT64_MAX)
+				printf(",\n\t\t\t\t\t\"sw-crypt-saturated\": true\n");
 		} else {
 			printf("\t\t\t\t\t\"hw-enc\": %lu,\n",
 			       stats[i].enc.hw);
+			if (stats[i].enc.hw == UINT64_MAX)
+				printf("\t\t\t\t\t\"hw-enc-saturated\": true,\n");
 			printf("\t\t\t\t\t\"sw-enc\": %lu,\n",
 			       stats[i].enc.sw);
+			if (stats[i].enc.sw == UINT64_MAX)
+				printf("\t\t\t\t\t\"sw-enc-saturated\": true,\n");
 			printf("\t\t\t\t\t\"hw-dec\": %lu,\n",
 			       stats[i].dec.hw);
+			if (stats[i].dec.hw == UINT64_MAX)
+				printf("\t\t\t\t\t\"hw-dec-saturated\": true,\n");
 			printf("\t\t\t\t\t\"sw-dec\": %lu\n",
 			       stats[i].dec.sw);
+			if (stats[i].dec.sw == UINT64_MAX)
+				printf(",\n\t\t\t\t\t\"sw-dec-saturated\": true\n");
 		}
 
 		printf("\t\t\t\t}");

--- a/src/icastats_shared.c
+++ b/src/icastats_shared.c
@@ -16,6 +16,7 @@
 #include <string.h>
 #include <stdlib.h>
 #include <errno.h>
+#include <limits.h>
 #include <unistd.h>
 #include <pwd.h>
 #include <sys/types.h>
@@ -28,6 +29,8 @@
 #include "init.h"
 
 #define NAME_LENGHT 20
+
+#define SAT_ADD(a, b) ((b) > UINT64_MAX - (a) ? UINT64_MAX : (a) + (b))
 
 static stats_entry_t *stats = NULL;
 
@@ -135,14 +138,14 @@ uint64_t stats_query(stats_entry_t *source, stats_fields_t field,
 
 	if (direction == ENCRYPT)
 		if (hardware == ALGO_HW)
-			return source[field].enc.hw;
+			return __sync_fetch_and_add(&source[field].enc.hw, 0);
 		else
-			return source[field].enc.sw;
+			return __sync_fetch_and_add(&source[field].enc.sw, 0);
 	else
 		if (hardware == ALGO_HW)
-			return source[field].dec.hw;
+			return __sync_fetch_and_add(&source[field].dec.hw, 0);
 		else
-			return source[field].dec.sw;
+			return __sync_fetch_and_add(&source[field].dec.sw, 0);
 }
 
 static uint64_t calc_summary(stats_entry_t *source,
@@ -150,10 +153,12 @@ static uint64_t calc_summary(stats_entry_t *source,
 		             int hardware, int direction)
 {
 	unsigned int i;
-	uint64_t sum = 0;
+	uint64_t sum = 0, val;
 
-	for (i = 0; i < num; i++)
-		sum += stats_query(source, start + i, hardware, direction);
+	for (i = 0; i < num; i++) {
+		val = stats_query(source, start + i, hardware, direction);
+		sum = SAT_ADD(sum, val);
+	}
 
 	return sum;
 }
@@ -278,11 +283,20 @@ int get_stats_sum(stats_entry_t *sum)
 				return 0;
 			}
 
-			for (i = 0; i<ICA_NUM_STATS; ++i) {
-				sum[i].enc.hw += tmp[i].enc.hw;
-				sum[i].enc.sw += tmp[i].enc.sw;
-				sum[i].dec.hw += tmp[i].dec.hw;
-				sum[i].dec.sw += tmp[i].dec.sw;
+			for (i = 0; i < ICA_NUM_STATS; ++i) {
+				uint64_t v;
+
+				v = __sync_fetch_and_add(&tmp[i].enc.hw, 0);
+				sum[i].enc.hw = SAT_ADD(sum[i].enc.hw, v);
+
+				v = __sync_fetch_and_add(&tmp[i].enc.sw, 0);
+				sum[i].enc.sw = SAT_ADD(sum[i].enc.sw, v);
+
+				v = __sync_fetch_and_add(&tmp[i].dec.hw, 0);
+				sum[i].dec.hw = SAT_ADD(sum[i].dec.hw, v);
+
+				v = __sync_fetch_and_add(&tmp[i].dec.sw, 0);
+				sum[i].dec.sw = SAT_ADD(sum[i].dec.sw, v);
 			}
 			munmap(tmp, STATS_SHM_SIZE);
 			close(fd);
@@ -347,6 +361,8 @@ char *get_next_usr()
 
 void stats_increment(stats_fields_t field, int hardware, int direction)
 {
+	uint64_t *counter, old, next, prev;
+
 	if (!ica_stats_enabled)
 		return;
 
@@ -355,14 +371,21 @@ void stats_increment(stats_fields_t field, int hardware, int direction)
 
 	if (direction == ENCRYPT)
 		if (hardware == ALGO_HW)
-			__sync_add_and_fetch(&stats[field].enc.hw, 1);
+			counter = &stats[field].enc.hw;
 		else
-			__sync_add_and_fetch(&stats[field].enc.sw, 1);
+			counter = &stats[field].enc.sw;
 	else
 		if (hardware == ALGO_HW)
-			__sync_add_and_fetch(&stats[field].dec.hw, 1);
+			counter = &stats[field].dec.hw;
 		else
-			__sync_add_and_fetch(&stats[field].dec.sw, 1);
+			counter = &stats[field].dec.sw;
+
+	old = *counter;
+	do {
+		prev = next = old;
+		if (next < UINT64_MAX)
+			next++;
+	} while ((old = __sync_val_compare_and_swap(counter, prev, next)) != prev);
 }
 #endif
 
@@ -371,10 +394,17 @@ void stats_increment(stats_fields_t field, int hardware, int direction)
  */
 void stats_reset()
 {
+	unsigned int i;
+
 	if (stats == NULL)
 		return;
 
-	memset(stats, 0, sizeof(stats_entry_t)*ICA_NUM_STATS);
+	for (i = 0; i < ICA_NUM_STATS; i++) {
+		__sync_and_and_fetch(&stats[i].enc.hw, 0);
+		__sync_and_and_fetch(&stats[i].enc.sw, 0);
+		__sync_and_and_fetch(&stats[i].dec.hw, 0);
+		__sync_and_and_fetch(&stats[i].dec.sw, 0);
+	}
 }
 
 


### PR DESCRIPTION
When statistic counters would overflow, keep them at the maximum possible value. Wrapping to zero is the worst possible outcome for an auditing tool, it silently under-reports activity.

If a counter saturated, then the icastats display indicates this with "[saturated]" instead of the counter value. JSON output will have an additional boolean field with the suffix '-saturated' set to 'true' emitted alongside the counter value.

Also make the reset operation to operate in an per counter atomic way. Otherwise counter increments might get lost while a reset is performed.

While at it, escape special charterers in JSON strings, as required by RFC 8259.